### PR TITLE
Added fuzzer

### DIFF
--- a/lib/fuzz/fuzz.go
+++ b/lib/fuzz/fuzz.go
@@ -1,0 +1,30 @@
+// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fuzz
+
+import(
+	"github.com/googleapis/gnostic/lib"
+	"strings"
+)
+
+func Fuzz(data []byte) int {
+	payload := strings.Fields(string(data))
+	g := lib.NewGnostic(payload)
+	err := g.Main()
+	if err != nil {
+		return 0
+	}
+	return 1
+}


### PR DESCRIPTION
This PR adds a fuzzer that targes the gnostic `Main()` function. 

I have setup an application to integrate gnostic on oss-fuzz which can be found [here](https://github.com/google/oss-fuzz/pull/3822). 

Integration into oss-fuzz requires at least one contact email address for bug reports. I have put my own as [an example](https://github.com/google/oss-fuzz/pull/3822/files#diff-e5c753c016c087ba782f86620012d2d6R2).

If there is interest in integrating with oss-fuzz, I ask kindly for the contact email addresses to add to the list of receivers for bug reports.