### PR TITLE
fixed build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/google/gnostic.svg?branch=master)](https://travis-ci.org/google/gnostic)
+
 # ⨁ gnostic
 
 This repository contains a Go command line tool which converts JSON and YAML

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![Build Status](https://travis-ci.org/googleapis/gnostic.svg?branch=master)](https://travis-ci.org/googleapis/gnostic)
-
 # ⨁ gnostic
 
 This repository contains a Go command line tool which converts JSON and YAML


### PR DESCRIPTION
Fixed build badge. The org name was `googleapis` instead of `google` in the build badge
fixes #224 