### PR TITLE
Update protoc-gen-openapi to represent map<string,string> as OpenAPI objects.

### DIFF
--- a/apps/protoc-gen-openapi/examples/tests/mapfields/message.proto
+++ b/apps/protoc-gen-openapi/examples/tests/mapfields/message.proto
@@ -1,0 +1,35 @@
+// Copyright 2021 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+package tests.mapfields.message.v1;
+
+import "google/api/annotations.proto";
+
+option go_package = "github.com/google/gnostic/apps/protoc-gen-openapi/examples/tests/mapfields/message/v1;message";
+
+service Messaging {
+    rpc UpdateMessage(Message) returns(Message) {
+        option(google.api.http) = {
+            patch: "/v1/messages/{message_id}"
+            body: "*"
+        };
+    }
+}
+message Message {
+    string message_id = 1;
+    map<string, string> labels = 2;
+}

--- a/apps/protoc-gen-openapi/examples/tests/mapfields/openapi.yaml
+++ b/apps/protoc-gen-openapi/examples/tests/mapfields/openapi.yaml
@@ -1,0 +1,32 @@
+# Generated with protoc-gen-openapi
+# https://github.com/googleapis/gnostic/tree/master/apps/protoc-gen-openapi
+
+openapi: 3.0.3
+info:
+    title: Messaging
+    version: 0.0.1
+paths:
+    /v1/messages/{message_id}:
+        patch:
+            operationId: Messaging_UpdateMessage
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/Message'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Message'
+components:
+    schemas:
+        Message:
+            properties:
+                message_id:
+                    type: string
+                labels:
+                    type: object

--- a/apps/protoc-gen-openapi/generator/openapi-v3.go
+++ b/apps/protoc-gen-openapi/generator/openapi-v3.go
@@ -484,6 +484,10 @@ func (g *OpenAPIv3Generator) addSchemasToDocumentV3(d *v3.Document, file *protog
 				default:
 					log.Printf("(TODO) Unsupported array type: %+v", fullMessageTypeName(field.Message))
 				}
+			} else if field.Desc.IsMap() &&
+				field.Desc.MapKey().Kind() == protoreflect.StringKind &&
+				field.Desc.MapValue().Kind() == protoreflect.StringKind {
+				fieldSchema.Type = "object"
 			} else {
 				k := field.Desc.Kind()
 				switch k {

--- a/apps/protoc-gen-openapi/plugin_test.go
+++ b/apps/protoc-gen-openapi/plugin_test.go
@@ -30,14 +30,12 @@ func TestLibraryOpenAPI(t *testing.T) {
 		"examples/google/example/library/v1/library.proto",
 		"--openapi_out=.").Run()
 	if err != nil {
-		t.Logf("protoc failed: %+v", err)
-		t.FailNow()
+		t.Fatalf("protoc failed: %+v", err)
 	}
 	// Verify that the generated spec matches our expected version.
 	err = exec.Command("diff", "openapi.yaml", "examples/google/example/library/v1/openapi.yaml").Run()
 	if err != nil {
-		t.Logf("Diff failed: %+v", err)
-		t.FailNow()
+		t.Fatalf("Diff failed: %+v", err)
 	}
 	// if the test succeeded, clean up
 	os.Remove("openapi.yaml")
@@ -53,14 +51,12 @@ func TestBodyMappingOpenAPI(t *testing.T) {
 		"examples/tests/bodymapping/message.proto",
 		"--openapi_out=.").Run()
 	if err != nil {
-		t.Logf("protoc failed: %+v", err)
-		t.FailNow()
+		t.Fatalf("protoc failed: %+v", err)
 	}
 	// Verify that the generated spec matches our expected version.
 	err = exec.Command("diff", "openapi.yaml", "examples/tests/bodymapping/openapi.yaml").Run()
 	if err != nil {
-		t.Logf("Diff failed: %+v", err)
-		t.FailNow()
+		t.Fatalf("Diff failed: %+v", err)
 	}
 	// if the test succeeded, clean up
 	os.Remove("openapi.yaml")
@@ -76,14 +72,12 @@ func TestMapFieldsOpenAPI(t *testing.T) {
 		"examples/tests/mapfields/message.proto",
 		"--openapi_out=.").Run()
 	if err != nil {
-		t.Logf("protoc failed: %+v", err)
-		t.FailNow()
+		t.Fatalf("protoc failed: %+v", err)
 	}
 	// Verify that the generated spec matches our expected version.
 	err = exec.Command("diff", "openapi.yaml", "examples/tests/mapfields/openapi.yaml").Run()
 	if err != nil {
-		t.Logf("Diff failed: %+v", err)
-		t.FailNow()
+		t.Fatalf("Diff failed: %+v", err)
 	}
 	// if the test succeeded, clean up
 	os.Remove("openapi.yaml")

--- a/apps/protoc-gen-openapi/plugin_test.go
+++ b/apps/protoc-gen-openapi/plugin_test.go
@@ -65,3 +65,26 @@ func TestBodyMappingOpenAPI(t *testing.T) {
 	// if the test succeeded, clean up
 	os.Remove("openapi.yaml")
 }
+
+func TestMapFieldsOpenAPI(t *testing.T) {
+	var err error
+	// Run protoc and the protoc-gen-openapi plugin to generate an OpenAPI spec.
+	err = exec.Command("protoc",
+		"-I", "../../",
+		"-I", "../../third_party",
+		"-I", "examples",
+		"examples/tests/mapfields/message.proto",
+		"--openapi_out=.").Run()
+	if err != nil {
+		t.Logf("protoc failed: %+v", err)
+		t.FailNow()
+	}
+	// Verify that the generated spec matches our expected version.
+	err = exec.Command("diff", "openapi.yaml", "examples/tests/mapfields/openapi.yaml").Run()
+	if err != nil {
+		t.Logf("Diff failed: %+v", err)
+		t.FailNow()
+	}
+	// if the test succeeded, clean up
+	os.Remove("openapi.yaml")
+}


### PR DESCRIPTION
As illustrated in the new test, this change causes map fields of the form:
```
map<string, string> labels = 2;
```
to be represented as "objects" in OpenAPI.
```
labels:
    type: object
```

This change was made to correctly generate https://github.com/apigee/registry/blob/main/openapi.yaml