### PR TITLE
Fixed incorrect interface nil check in protoc-gen-openapi

### DIFF
--- a/apps/protoc-gen-openapi/generator/openapi-v3.go
+++ b/apps/protoc-gen-openapi/generator/openapi-v3.go
@@ -127,11 +127,12 @@ func (g *OpenAPIv3Generator) addPathsToDocumentV3(d *v3.Document, file *protogen
 			inputMessage := method.Input
 			outputMessage := method.Output
 			operationID := service.GoName + "_" + method.GoName
-			extension := proto.GetExtension(method.Desc.Options(), annotations.E_Http)
+			xt := annotations.E_Http
+			extension := proto.GetExtension(method.Desc.Options(), xt)
 			var path string
 			var methodName string
 			var body string
-			if extension != nil {
+			if extension != nil && extension != xt.InterfaceOf(xt.Zero()) {
 				rule := extension.(*annotations.HttpRule)
 				body = rule.Body
 				switch pattern := rule.Pattern.(type) {


### PR DESCRIPTION
The `extension` variable is an interface and was only checked for `nil`, but not whether `xt.Zero()` would be assigned to the interface.
This leads to a crash, if a method within a service was not annotated.

Closes #248
