### PR TITLE
protoc-gen-openapi: Convert maps and lists of sub messages

### DIFF
--- a/apps/protoc-gen-openapi/examples/tests/mapfields/message.proto
+++ b/apps/protoc-gen-openapi/examples/tests/mapfields/message.proto
@@ -38,10 +38,11 @@ message SubMessage {
 
 message Message {
     string message_id = 1;
-    repeated string string_list = 2;
-    repeated SubMessage sub_message_list = 3;
-    repeated google.protobuf.Struct object_list = 4;
-    map<string, string> strings_map = 5;
-    map<string, SubMessage> sub_messages_map = 6;
-    map<string, google.protobuf.Struct> objects_map = 7;
+    SubMessage sub_message = 2;
+    repeated string string_list = 3;
+    repeated SubMessage sub_message_list = 4;
+    repeated google.protobuf.Struct object_list = 5;
+    map<string, string> strings_map = 6;
+    map<string, SubMessage> sub_messages_map = 7;
+    map<string, google.protobuf.Struct> objects_map = 8;
 }

--- a/apps/protoc-gen-openapi/examples/tests/mapfields/message.proto
+++ b/apps/protoc-gen-openapi/examples/tests/mapfields/message.proto
@@ -18,6 +18,7 @@ syntax = "proto3";
 package tests.mapfields.message.v1;
 
 import "google/api/annotations.proto";
+import "google/protobuf/struct.proto";
 
 option go_package = "github.com/google/gnostic/apps/protoc-gen-openapi/examples/tests/mapfields/message/v1;message";
 
@@ -29,7 +30,18 @@ service Messaging {
         };
     }
 }
+
+message SubMessage {
+    int64 id = 1;
+    string label = 2;
+}
+
 message Message {
     string message_id = 1;
-    map<string, string> labels = 2;
+    repeated string string_list = 2;
+    repeated SubMessage sub_message_list = 3;
+    repeated google.protobuf.Struct object_list = 4;
+    map<string, string> strings_map = 5;
+    map<string, SubMessage> sub_messages_map = 6;
+    map<string, google.protobuf.Struct> objects_map = 7;
 }

--- a/apps/protoc-gen-openapi/examples/tests/mapfields/openapi.yaml
+++ b/apps/protoc-gen-openapi/examples/tests/mapfields/openapi.yaml
@@ -36,6 +36,8 @@ components:
             properties:
                 message_id:
                     type: string
+                sub_message:
+                    $ref: '#/components/schemas/SubMessage'
                 string_list:
                     type: array
                     items:
@@ -49,11 +51,17 @@ components:
                     items:
                         type: object
                 strings_map:
-                    type: string
+                    type: object
+                    additionalProperties:
+                        type: string
                 sub_messages_map:
-                    $ref: '#/components/schemas/SubMessage'
+                    type: object
+                    additionalProperties:
+                        $ref: '#/components/schemas/SubMessage'
                 objects_map:
                     type: object
+                    additionalProperties:
+                        type: object
         SubMessage:
             properties:
                 id:

--- a/apps/protoc-gen-openapi/examples/tests/mapfields/openapi.yaml
+++ b/apps/protoc-gen-openapi/examples/tests/mapfields/openapi.yaml
@@ -36,7 +36,30 @@ components:
             properties:
                 message_id:
                     type: string
-                labels:
+                string_list:
+                    type: array
+                    items:
+                        type: string
+                sub_message_list:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/SubMessage'
+                object_list:
+                    type: array
+                    items:
+                        type: object
+                strings_map:
+                    type: string
+                sub_messages_map:
+                    $ref: '#/components/schemas/SubMessage'
+                objects_map:
                     type: object
+        SubMessage:
+            properties:
+                id:
+                    type: integer
+                    format: int64
+                label:
+                    type: string
 tags:
     - name: Messaging

--- a/apps/protoc-gen-openapi/examples/tests/mapfields/openapi_json.yaml
+++ b/apps/protoc-gen-openapi/examples/tests/mapfields/openapi_json.yaml
@@ -36,7 +36,30 @@ components:
             properties:
                 messageId:
                     type: string
-                labels:
+                stringList:
+                    type: array
+                    items:
+                        type: string
+                subMessageList:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/SubMessage'
+                objectList:
+                    type: array
+                    items:
+                        type: object
+                stringsMap:
+                    type: string
+                subMessagesMap:
+                    $ref: '#/components/schemas/SubMessage'
+                objectsMap:
                     type: object
+        SubMessage:
+            properties:
+                id:
+                    type: integer
+                    format: int64
+                label:
+                    type: string
 tags:
     - name: Messaging

--- a/apps/protoc-gen-openapi/examples/tests/mapfields/openapi_json.yaml
+++ b/apps/protoc-gen-openapi/examples/tests/mapfields/openapi_json.yaml
@@ -36,6 +36,8 @@ components:
             properties:
                 messageId:
                     type: string
+                subMessage:
+                    $ref: '#/components/schemas/SubMessage'
                 stringList:
                     type: array
                     items:
@@ -49,11 +51,17 @@ components:
                     items:
                         type: object
                 stringsMap:
-                    type: string
+                    type: object
+                    additionalProperties:
+                        type: string
                 subMessagesMap:
-                    $ref: '#/components/schemas/SubMessage'
+                    type: object
+                    additionalProperties:
+                        $ref: '#/components/schemas/SubMessage'
                 objectsMap:
                     type: object
+                    additionalProperties:
+                        type: object
         SubMessage:
             properties:
                 id:

--- a/apps/protoc-gen-openapi/generator/openapi-v3.go
+++ b/apps/protoc-gen-openapi/generator/openapi-v3.go
@@ -603,7 +603,12 @@ func (g *OpenAPIv3Generator) schemaOrReferenceForType(typeName string) *v3.Schem
 
 func (g *OpenAPIv3Generator) schemaOrReferenceForField(field protoreflect.FieldDescriptor) *v3.SchemaOrReference {
 	if field.IsMap() {
-		return g.schemaOrReferenceForField(field.MapValue())
+		return &v3.SchemaOrReference{
+			Oneof: &v3.SchemaOrReference_Schema{
+				Schema: &v3.Schema{Type: "object",
+					AdditionalProperties: &v3.AdditionalPropertiesItem{
+						Oneof: &v3.AdditionalPropertiesItem_SchemaOrReference{
+							SchemaOrReference: g.schemaOrReferenceForField(field.MapValue())}}}}}
 	}
 
 	var kindSchema *v3.SchemaOrReference


### PR DESCRIPTION
This ensures proper conversion of maps and lists of standard types, (some) google.protobuf types and sub messages.