### PR TITLE
protoc-gen-openapi: schema types

### DIFF
--- a/apps/protoc-gen-openapi/examples/google/example/library/v1/openapi.yaml
+++ b/apps/protoc-gen-openapi/examples/google/example/library/v1/openapi.yaml
@@ -314,6 +314,7 @@ paths:
 components:
     schemas:
         Book:
+            type: object
             required:
                 - name
             properties:
@@ -346,6 +347,7 @@ components:
                     format: date-time
             description: A single book in the library.
         ListBooksResponse:
+            type: object
             properties:
                 books:
                     type: array
@@ -357,6 +359,7 @@ components:
                     description: A token to retrieve next page of results. Pass this value in the [ListBooksRequest.page_token][google.example.library.v1.ListBooksRequest.page_token] field in the subsequent call to `ListBooks` method to retrieve the next page of results.
             description: Response message for LibraryService.ListBooks.
         ListShelvesResponse:
+            type: object
             properties:
                 shelves:
                     type: array
@@ -368,6 +371,7 @@ components:
                     description: A token to retrieve next page of results. Pass this value in the [ListShelvesRequest.page_token][google.example.library.v1.ListShelvesRequest.page_token] field in the subsequent call to `ListShelves` method to retrieve the next page of results.
             description: Response message for LibraryService.ListShelves.
         MergeShelvesRequest:
+            type: object
             required:
                 - name
                 - other_shelf_name
@@ -380,6 +384,7 @@ components:
                     description: The name of the shelf we're removing books from and deleting.
             description: Describes the shelf being removed (other_shelf_name) and updated (name) in this merge.
         MoveBookRequest:
+            type: object
             required:
                 - name
                 - other_shelf_name
@@ -392,6 +397,7 @@ components:
                     description: The name of the destination shelf.
             description: Describes what book to move (name) and what shelf we're moving it to (other_shelf_name).
         Shelf:
+            type: object
             required:
                 - name
             properties:

--- a/apps/protoc-gen-openapi/examples/google/example/library/v1/openapi_json.yaml
+++ b/apps/protoc-gen-openapi/examples/google/example/library/v1/openapi_json.yaml
@@ -314,6 +314,7 @@ paths:
 components:
     schemas:
         Book:
+            type: object
             required:
                 - name
             properties:
@@ -346,6 +347,7 @@ components:
                     format: date-time
             description: A single book in the library.
         ListBooksResponse:
+            type: object
             properties:
                 books:
                     type: array
@@ -357,6 +359,7 @@ components:
                     description: A token to retrieve next page of results. Pass this value in the [ListBooksRequest.page_token][google.example.library.v1.ListBooksRequest.page_token] field in the subsequent call to `ListBooks` method to retrieve the next page of results.
             description: Response message for LibraryService.ListBooks.
         ListShelvesResponse:
+            type: object
             properties:
                 shelves:
                     type: array
@@ -368,6 +371,7 @@ components:
                     description: A token to retrieve next page of results. Pass this value in the [ListShelvesRequest.page_token][google.example.library.v1.ListShelvesRequest.page_token] field in the subsequent call to `ListShelves` method to retrieve the next page of results.
             description: Response message for LibraryService.ListShelves.
         MergeShelvesRequest:
+            type: object
             required:
                 - name
                 - otherShelfName
@@ -380,6 +384,7 @@ components:
                     description: The name of the shelf we're removing books from and deleting.
             description: Describes the shelf being removed (other_shelf_name) and updated (name) in this merge.
         MoveBookRequest:
+            type: object
             required:
                 - name
                 - otherShelfName
@@ -392,6 +397,7 @@ components:
                     description: The name of the destination shelf.
             description: Describes what book to move (name) and what shelf we're moving it to (other_shelf_name).
         Shelf:
+            type: object
             required:
                 - name
             properties:

--- a/apps/protoc-gen-openapi/generator/openapi-v3.go
+++ b/apps/protoc-gen-openapi/generator/openapi-v3.go
@@ -957,6 +957,7 @@ func (g *OpenAPIv3Generator) addSchemasToDocumentV3(d *v3.Document, messages []*
 							Description: messageDescription,
 							Properties:  definitionProperties,
 							Required:    required,
+							Type:        "object",
 						},
 					},
 				},


### PR DESCRIPTION
Schema types are required when auto generating code from OpenAPI.
[Issue](https://github.com/google/gnostic/issues/263) was created some time ago.
```
Schema:
    type: object
    required:
     - name
    properties:
      name:
        type: string
        description: service name
```