### PR TITLE
protoc-gen-openapi: Add type to schema objects

### DIFF
--- a/apps/protoc-gen-openapi/examples/google/example/library/v1/openapi.yaml
+++ b/apps/protoc-gen-openapi/examples/google/example/library/v1/openapi.yaml
@@ -316,6 +316,7 @@ components:
         Book:
             required:
                 - name
+            type: object
             properties:
                 name:
                     type: string
@@ -346,6 +347,7 @@ components:
                     format: date-time
             description: A single book in the library.
         ListBooksResponse:
+            type: object
             properties:
                 books:
                     type: array
@@ -357,6 +359,7 @@ components:
                     description: A token to retrieve next page of results. Pass this value in the [ListBooksRequest.page_token][google.example.library.v1.ListBooksRequest.page_token] field in the subsequent call to `ListBooks` method to retrieve the next page of results.
             description: Response message for LibraryService.ListBooks.
         ListShelvesResponse:
+            type: object
             properties:
                 shelves:
                     type: array
@@ -371,6 +374,7 @@ components:
             required:
                 - name
                 - other_shelf_name
+            type: object
             properties:
                 name:
                     type: string
@@ -383,6 +387,7 @@ components:
             required:
                 - name
                 - other_shelf_name
+            type: object
             properties:
                 name:
                     type: string
@@ -394,6 +399,7 @@ components:
         Shelf:
             required:
                 - name
+            type: object
             properties:
                 name:
                     type: string

--- a/apps/protoc-gen-openapi/examples/google/example/library/v1/openapi_json.yaml
+++ b/apps/protoc-gen-openapi/examples/google/example/library/v1/openapi_json.yaml
@@ -316,6 +316,7 @@ components:
         Book:
             required:
                 - name
+            type: object
             properties:
                 name:
                     type: string
@@ -346,6 +347,7 @@ components:
                     format: date-time
             description: A single book in the library.
         ListBooksResponse:
+            type: object
             properties:
                 books:
                     type: array
@@ -357,6 +359,7 @@ components:
                     description: A token to retrieve next page of results. Pass this value in the [ListBooksRequest.page_token][google.example.library.v1.ListBooksRequest.page_token] field in the subsequent call to `ListBooks` method to retrieve the next page of results.
             description: Response message for LibraryService.ListBooks.
         ListShelvesResponse:
+            type: object
             properties:
                 shelves:
                     type: array
@@ -371,6 +374,7 @@ components:
             required:
                 - name
                 - otherShelfName
+            type: object
             properties:
                 name:
                     type: string
@@ -383,6 +387,7 @@ components:
             required:
                 - name
                 - otherShelfName
+            type: object
             properties:
                 name:
                     type: string
@@ -394,6 +399,7 @@ components:
         Shelf:
             required:
                 - name
+            type: object
             properties:
                 name:
                     type: string

--- a/apps/protoc-gen-openapi/examples/tests/bodymapping/openapi.yaml
+++ b/apps/protoc-gen-openapi/examples/tests/bodymapping/openapi.yaml
@@ -33,6 +33,7 @@ paths:
 components:
     schemas:
         Message:
+            type: object
             properties:
                 message_id:
                     type: string

--- a/apps/protoc-gen-openapi/examples/tests/bodymapping/openapi_json.yaml
+++ b/apps/protoc-gen-openapi/examples/tests/bodymapping/openapi_json.yaml
@@ -33,6 +33,7 @@ paths:
 components:
     schemas:
         Message:
+            type: object
             properties:
                 messageId:
                     type: string

--- a/apps/protoc-gen-openapi/examples/tests/jsonoptions/openapi.yaml
+++ b/apps/protoc-gen-openapi/examples/tests/jsonoptions/openapi.yaml
@@ -65,6 +65,7 @@ paths:
 components:
     schemas:
         Message:
+            type: object
             properties:
                 message_id:
                     type: string
@@ -73,6 +74,7 @@ components:
                 not_used:
                     type: string
         Message2:
+            type: object
             properties:
                 message_id:
                     type: string

--- a/apps/protoc-gen-openapi/examples/tests/jsonoptions/openapi_json.yaml
+++ b/apps/protoc-gen-openapi/examples/tests/jsonoptions/openapi_json.yaml
@@ -66,6 +66,7 @@ paths:
 components:
     schemas:
         Message:
+            type: object
             properties:
                 messageId:
                     type: string
@@ -74,6 +75,7 @@ components:
                 notUsed:
                     type: string
         Message2:
+            type: object
             properties:
                 message_id:
                     type: string

--- a/apps/protoc-gen-openapi/examples/tests/mapfields/openapi.yaml
+++ b/apps/protoc-gen-openapi/examples/tests/mapfields/openapi.yaml
@@ -33,6 +33,7 @@ paths:
 components:
     schemas:
         AnotherMessage:
+            type: object
             properties:
                 id:
                     type: integer
@@ -40,6 +41,7 @@ components:
                 label:
                     type: string
         Message:
+            type: object
             properties:
                 message_id:
                     type: string
@@ -72,6 +74,7 @@ components:
                     additionalProperties:
                         type: object
         Message_SubMessage:
+            type: object
             properties:
                 id:
                     type: integer

--- a/apps/protoc-gen-openapi/examples/tests/mapfields/openapi_json.yaml
+++ b/apps/protoc-gen-openapi/examples/tests/mapfields/openapi_json.yaml
@@ -33,6 +33,7 @@ paths:
 components:
     schemas:
         AnotherMessage:
+            type: object
             properties:
                 id:
                     type: integer
@@ -40,6 +41,7 @@ components:
                 label:
                     type: string
         Message:
+            type: object
             properties:
                 messageId:
                     type: string
@@ -72,6 +74,7 @@ components:
                     additionalProperties:
                         type: object
         Message_SubMessage:
+            type: object
             properties:
                 id:
                     type: integer

--- a/apps/protoc-gen-openapi/examples/tests/noannotations/openapi.yaml
+++ b/apps/protoc-gen-openapi/examples/tests/noannotations/openapi.yaml
@@ -33,6 +33,7 @@ paths:
 components:
     schemas:
         Message:
+            type: object
             properties:
                 id:
                     type: integer

--- a/apps/protoc-gen-openapi/examples/tests/noannotations/openapi_json.yaml
+++ b/apps/protoc-gen-openapi/examples/tests/noannotations/openapi_json.yaml
@@ -33,6 +33,7 @@ paths:
 components:
     schemas:
         Message:
+            type: object
             properties:
                 id:
                     type: integer

--- a/apps/protoc-gen-openapi/examples/tests/pathparams/openapi.yaml
+++ b/apps/protoc-gen-openapi/examples/tests/pathparams/openapi.yaml
@@ -79,6 +79,7 @@ paths:
 components:
     schemas:
         Message:
+            type: object
             properties:
                 message_id:
                     type: string

--- a/apps/protoc-gen-openapi/examples/tests/pathparams/openapi_json.yaml
+++ b/apps/protoc-gen-openapi/examples/tests/pathparams/openapi_json.yaml
@@ -79,6 +79,7 @@ paths:
 components:
     schemas:
         Message:
+            type: object
             properties:
                 messageId:
                     type: string

--- a/apps/protoc-gen-openapi/examples/tests/protobuftypes/openapi.yaml
+++ b/apps/protoc-gen-openapi/examples/tests/protobuftypes/openapi.yaml
@@ -170,6 +170,7 @@ paths:
 components:
     schemas:
         Message:
+            type: object
             properties:
                 message_id:
                     type: string
@@ -204,10 +205,12 @@ components:
                     items:
                         type: object
         Message_EmbMessage:
+            type: object
             properties:
                 message_id:
                     type: string
         RecursiveChild:
+            type: object
             properties:
                 child_id:
                     type: integer
@@ -215,6 +218,7 @@ components:
                 parent:
                     $ref: '#/components/schemas/RecursiveParent'
         RecursiveParent:
+            type: object
             properties:
                 parent_id:
                     type: integer
@@ -222,12 +226,14 @@ components:
                 child:
                     $ref: '#/components/schemas/RecursiveChild'
         SubMessage:
+            type: object
             properties:
                 message_id:
                     type: string
                 sub_sub_message:
                     $ref: '#/components/schemas/SubSubMessage'
         SubSubMessage:
+            type: object
             properties:
                 message_id:
                     type: string

--- a/apps/protoc-gen-openapi/examples/tests/protobuftypes/openapi_json.yaml
+++ b/apps/protoc-gen-openapi/examples/tests/protobuftypes/openapi_json.yaml
@@ -170,6 +170,7 @@ paths:
 components:
     schemas:
         Message:
+            type: object
             properties:
                 messageId:
                     type: string
@@ -204,10 +205,12 @@ components:
                     items:
                         type: object
         Message_EmbMessage:
+            type: object
             properties:
                 messageId:
                     type: string
         RecursiveChild:
+            type: object
             properties:
                 childId:
                     type: integer
@@ -215,6 +218,7 @@ components:
                 parent:
                     $ref: '#/components/schemas/RecursiveParent'
         RecursiveParent:
+            type: object
             properties:
                 parentId:
                     type: integer
@@ -222,12 +226,14 @@ components:
                 child:
                     $ref: '#/components/schemas/RecursiveChild'
         SubMessage:
+            type: object
             properties:
                 messageId:
                     type: string
                 subSubMessage:
                     $ref: '#/components/schemas/SubSubMessage'
         SubSubMessage:
+            type: object
             properties:
                 messageId:
                     type: string

--- a/apps/protoc-gen-openapi/generator/openapi-v3.go
+++ b/apps/protoc-gen-openapi/generator/openapi-v3.go
@@ -954,6 +954,7 @@ func (g *OpenAPIv3Generator) addSchemasToDocumentV3(d *v3.Document, messages []*
 				Value: &v3.SchemaOrReference{
 					Oneof: &v3.SchemaOrReference_Schema{
 						Schema: &v3.Schema{
+							Type:        "object",
 							Description: messageDescription,
 							Properties:  definitionProperties,
 							Required:    required,


### PR DESCRIPTION
All schemas defined in "components" will now have "type" set to "object".