### PR TITLE
Retract v0.6.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,3 +14,7 @@ require (
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
 )
+
+retract (
+    v0.6.0 // Introduced multi modules, which was removed in v.0.6.1.
+)


### PR DESCRIPTION
Remove any knowledge of multi modules from pkg.go.dev, etc.