### PR TITLE
cmd/protoc-gen-openapi/generator: fix Openapi version to 3.1.0

### DIFF
--- a/cmd/protoc-gen-openapi/examples/google/example/library/v1/openapi.yaml
+++ b/cmd/protoc-gen-openapi/examples/google/example/library/v1/openapi.yaml
@@ -1,7 +1,7 @@
 # Generated with protoc-gen-openapi
 # https://github.com/google/gnostic/tree/master/cmd/protoc-gen-openapi
 
-openapi: 3.0.3
+openapi: 3.1.0
 info:
     title: LibraryService API
     description: |-

--- a/cmd/protoc-gen-openapi/examples/google/example/library/v1/openapi_json.yaml
+++ b/cmd/protoc-gen-openapi/examples/google/example/library/v1/openapi_json.yaml
@@ -1,7 +1,7 @@
 # Generated with protoc-gen-openapi
 # https://github.com/google/gnostic/tree/master/cmd/protoc-gen-openapi
 
-openapi: 3.0.3
+openapi: 3.1.0
 info:
     title: LibraryService API
     description: |-

--- a/cmd/protoc-gen-openapi/examples/tests/bodymapping/openapi.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/bodymapping/openapi.yaml
@@ -1,7 +1,7 @@
 # Generated with protoc-gen-openapi
 # https://github.com/google/gnostic/tree/master/cmd/protoc-gen-openapi
 
-openapi: 3.0.3
+openapi: 3.1.0
 info:
     title: Messaging API
     version: 0.0.1

--- a/cmd/protoc-gen-openapi/examples/tests/bodymapping/openapi_json.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/bodymapping/openapi_json.yaml
@@ -1,7 +1,7 @@
 # Generated with protoc-gen-openapi
 # https://github.com/google/gnostic/tree/master/cmd/protoc-gen-openapi
 
-openapi: 3.0.3
+openapi: 3.1.0
 info:
     title: Messaging API
     version: 1.2.3

--- a/cmd/protoc-gen-openapi/examples/tests/jsonoptions/openapi.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/jsonoptions/openapi.yaml
@@ -1,7 +1,7 @@
 # Generated with protoc-gen-openapi
 # https://github.com/google/gnostic/tree/master/cmd/protoc-gen-openapi
 
-openapi: 3.0.3
+openapi: 3.1.0
 info:
     title: Messaging API
     description: Messaging service

--- a/cmd/protoc-gen-openapi/examples/tests/jsonoptions/openapi_json.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/jsonoptions/openapi_json.yaml
@@ -1,7 +1,7 @@
 # Generated with protoc-gen-openapi
 # https://github.com/google/gnostic/tree/master/cmd/protoc-gen-openapi
 
-openapi: 3.0.3
+openapi: 3.1.0
 info:
     title: Messaging API
     description: Messaging service

--- a/cmd/protoc-gen-openapi/examples/tests/mapfields/openapi.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/mapfields/openapi.yaml
@@ -1,7 +1,7 @@
 # Generated with protoc-gen-openapi
 # https://github.com/google/gnostic/tree/master/cmd/protoc-gen-openapi
 
-openapi: 3.0.3
+openapi: 3.1.0
 info:
     title: Messaging API
     version: 0.0.1

--- a/cmd/protoc-gen-openapi/examples/tests/mapfields/openapi_json.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/mapfields/openapi_json.yaml
@@ -1,7 +1,7 @@
 # Generated with protoc-gen-openapi
 # https://github.com/google/gnostic/tree/master/cmd/protoc-gen-openapi
 
-openapi: 3.0.3
+openapi: 3.1.0
 info:
     title: Messaging API
     version: 1.2.3

--- a/cmd/protoc-gen-openapi/examples/tests/noannotations/openapi.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/noannotations/openapi.yaml
@@ -1,7 +1,7 @@
 # Generated with protoc-gen-openapi
 # https://github.com/google/gnostic/tree/master/cmd/protoc-gen-openapi
 
-openapi: 3.0.3
+openapi: 3.1.0
 info:
     title: Messaging1 API
     version: 0.0.1

--- a/cmd/protoc-gen-openapi/examples/tests/noannotations/openapi_json.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/noannotations/openapi_json.yaml
@@ -1,7 +1,7 @@
 # Generated with protoc-gen-openapi
 # https://github.com/google/gnostic/tree/master/cmd/protoc-gen-openapi
 
-openapi: 3.0.3
+openapi: 3.1.0
 info:
     title: Messaging1 API
     version: 1.2.3

--- a/cmd/protoc-gen-openapi/examples/tests/pathparams/openapi.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/pathparams/openapi.yaml
@@ -1,7 +1,7 @@
 # Generated with protoc-gen-openapi
 # https://github.com/google/gnostic/tree/master/cmd/protoc-gen-openapi
 
-openapi: 3.0.3
+openapi: 3.1.0
 info:
     title: Messaging API
     version: 0.0.1

--- a/cmd/protoc-gen-openapi/examples/tests/pathparams/openapi_json.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/pathparams/openapi_json.yaml
@@ -1,7 +1,7 @@
 # Generated with protoc-gen-openapi
 # https://github.com/google/gnostic/tree/master/cmd/protoc-gen-openapi
 
-openapi: 3.0.3
+openapi: 3.1.0
 info:
     title: Messaging API
     version: 1.2.3

--- a/cmd/protoc-gen-openapi/examples/tests/protobuftypes/openapi.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/protobuftypes/openapi.yaml
@@ -1,7 +1,7 @@
 # Generated with protoc-gen-openapi
 # https://github.com/google/gnostic/tree/master/cmd/protoc-gen-openapi
 
-openapi: 3.0.3
+openapi: 3.1.0
 info:
     title: Messaging API
     version: 0.0.1

--- a/cmd/protoc-gen-openapi/examples/tests/protobuftypes/openapi_json.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/protobuftypes/openapi_json.yaml
@@ -1,7 +1,7 @@
 # Generated with protoc-gen-openapi
 # https://github.com/google/gnostic/tree/master/cmd/protoc-gen-openapi
 
-openapi: 3.0.3
+openapi: 3.1.0
 info:
     title: Messaging API
     version: 1.2.3

--- a/cmd/protoc-gen-openapi/generator/openapi-v3.go
+++ b/cmd/protoc-gen-openapi/generator/openapi-v3.go
@@ -86,7 +86,7 @@ func (g *OpenAPIv3Generator) Run() error {
 func (g *OpenAPIv3Generator) buildDocumentV3() *v3.Document {
 	d := &v3.Document{}
 
-	d.Openapi = "3.0.3"
+	d.Openapi = "3.1.0"
 	d.Info = &v3.Info{
 		Version:     *g.conf.Version,
 		Title:       *g.conf.Title,


### PR DESCRIPTION
cmd/protoc-gen-openapi/generator: fix Openapi version to 3.1.0.

github.com/google/gnostic/openapiv3 already supports 3.1.0.