### PR TITLE
protoc-gen-openapi/jsonschema: Add support for string-based enums

### DIFF
--- a/cmd/protoc-gen-jsonschema/main.go
+++ b/cmd/protoc-gen-jsonschema/main.go
@@ -18,7 +18,7 @@ package main
 import (
 	"flag"
 
-    "github.com/google/gnostic/cmd/protoc-gen-jsonschema/generator"
+	"github.com/google/gnostic/cmd/protoc-gen-jsonschema/generator"
 	"google.golang.org/protobuf/compiler/protogen"
 	"google.golang.org/protobuf/types/pluginpb"
 )
@@ -27,9 +27,10 @@ var flags flag.FlagSet
 
 func main() {
 	conf := generator.Configuration{
-		BaseURL: flags.String("baseurl", "", "the base url to use in schema ids"),
-		Version: flags.String("version", "http://json-schema.org/draft-07/schema#", "schema version URL used in $schema. Currently supported: draft-06, draft-07"),
-		Naming:  flags.String("naming", "json", `naming convention. Use "proto" for passing names directly from the proto files`),
+		BaseURL:  flags.String("baseurl", "", "the base url to use in schema ids"),
+		Version:  flags.String("version", "http://json-schema.org/draft-07/schema#", "schema version URL used in $schema. Currently supported: draft-06, draft-07"),
+		Naming:   flags.String("naming", "json", `naming convention. Use "proto" for passing names directly from the proto files`),
+		EnumType: flags.String("enum_type", "integer", `type for enum serialization. Use "string" for string-based serialization`),
 	}
 
 	opts := protogen.Options{

--- a/cmd/protoc-gen-openapi/examples/tests/enumoptions/message.proto
+++ b/cmd/protoc-gen-openapi/examples/tests/enumoptions/message.proto
@@ -1,0 +1,40 @@
+// Copyright 2020 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+package tests.enumoptions.message.v1;
+
+import "google/api/annotations.proto";
+
+option go_package = "github.com/google/gnostic/apps/protoc-gen-openapi/examples/tests/enumoptions/message/v1;message";
+
+// Messaging service
+service Messaging {
+  rpc CreateMessage(Message) returns (Message) {
+    option (google.api.http) = {
+      post : "/v1/messages/{message_id}"
+      body : "body_text"
+    };
+  }
+}
+message Message {
+  Kind kind = 1;
+}
+enum Kind {
+  UNKNOWN_KIND = 0;
+  KIND_1 = 1;
+  KIND_2 = 2;
+}

--- a/cmd/protoc-gen-openapi/examples/tests/enumoptions/openapi.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/enumoptions/openapi.yaml
@@ -1,0 +1,46 @@
+# Generated with protoc-gen-openapi
+# https://github.com/google/gnostic/tree/master/cmd/protoc-gen-openapi
+
+openapi: 3.0.3
+info:
+    title: Messaging API
+    description: Messaging service
+    version: 0.0.1
+paths:
+    /v1/messages/{message_id}:
+        post:
+            tags:
+                - Messaging
+            operationId: Messaging_CreateMessage
+            parameters:
+                - name: message_id
+                  in: path
+                  required: true
+                  schema:
+                    type: string
+                - name: kind
+                  in: query
+                  schema:
+                    type: integer
+                    format: enum
+            requestBody:
+                content:
+                    application/json: {}
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Message'
+components:
+    schemas:
+        Message:
+            type: object
+            properties:
+                kind:
+                    type: integer
+                    format: enum
+tags:
+    - name: Messaging

--- a/cmd/protoc-gen-openapi/examples/tests/enumoptions/openapi_string_enum.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/enumoptions/openapi_string_enum.yaml
@@ -1,0 +1,54 @@
+# Generated with protoc-gen-openapi
+# https://github.com/google/gnostic/tree/master/cmd/protoc-gen-openapi
+
+openapi: 3.0.3
+info:
+    title: Messaging API
+    description: Messaging service
+    version: 0.0.1
+paths:
+    /v1/messages/{message_id}:
+        post:
+            tags:
+                - Messaging
+            operationId: Messaging_CreateMessage
+            parameters:
+                - name: message_id
+                  in: path
+                  required: true
+                  schema:
+                    type: string
+                - name: kind
+                  in: query
+                  schema:
+                    enum:
+                        - UNKNOWN_KIND
+                        - KIND_1
+                        - KIND_2
+                    type: string
+                    format: enum
+            requestBody:
+                content:
+                    application/json: {}
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Message'
+components:
+    schemas:
+        Message:
+            type: object
+            properties:
+                kind:
+                    enum:
+                        - UNKNOWN_KIND
+                        - KIND_1
+                        - KIND_2
+                    type: string
+                    format: enum
+tags:
+    - name: Messaging

--- a/cmd/protoc-gen-openapi/generator/openapi-v3.go
+++ b/cmd/protoc-gen-openapi/generator/openapi-v3.go
@@ -36,6 +36,7 @@ type Configuration struct {
 	Title         *string
 	Description   *string
 	Naming        *string
+	EnumType      *string
 	CircularDepth *int
 }
 
@@ -835,9 +836,21 @@ func (g *OpenAPIv3Generator) schemaOrReferenceForField(field protoreflect.FieldD
 				Schema: &v3.Schema{Type: "integer", Format: kind.String()}}}
 
 	case protoreflect.EnumKind:
+		s := &v3.Schema{Format: "enum"}
+		if g.conf.EnumType != nil && *g.conf.EnumType == "string" {
+			s.Type = "string"
+			s.Enum = make([]*v3.Any, 0, field.Enum().Values().Len())
+			for i := 0; i < field.Enum().Values().Len(); i++ {
+				s.Enum = append(s.Enum, &v3.Any{
+					Yaml: string(field.Enum().Values().Get(i).Name()),
+				})
+			}
+		} else {
+			s.Type = "integer"
+		}
 		kindSchema = &v3.SchemaOrReference{
 			Oneof: &v3.SchemaOrReference_Schema{
-				Schema: &v3.Schema{Type: "integer", Format: "enum"}}}
+				Schema: s}}
 
 	case protoreflect.BoolKind:
 		kindSchema = &v3.SchemaOrReference{

--- a/cmd/protoc-gen-openapi/main.go
+++ b/cmd/protoc-gen-openapi/main.go
@@ -18,7 +18,7 @@ package main
 import (
 	"flag"
 
-    "github.com/google/gnostic/cmd/protoc-gen-openapi/generator"
+	"github.com/google/gnostic/cmd/protoc-gen-openapi/generator"
 	"google.golang.org/protobuf/compiler/protogen"
 	"google.golang.org/protobuf/types/pluginpb"
 )
@@ -31,7 +31,8 @@ func main() {
 		Title:         flags.String("title", "", "name of the API"),
 		Description:   flags.String("description", "", "description of the API"),
 		Naming:        flags.String("naming", "json", `naming convention. Use "proto" for passing names directly from the proto files`),
-		CircularDepth: flags.Int("depth", 2, `depth of recursion for circular messages`),
+		EnumType:      flags.String("enum_type", "integer", `type for enum serialization. Use "string" for string-based serialization`),
+		CircularDepth: flags.Int("depth", 2, "depth of recursion for circular messages"),
 	}
 
 	opts := protogen.Options{


### PR DESCRIPTION
This change exposes a configuration option that enables Protobuf enums to be compiled to enums with the underlying type of `string`.

The following Protobuf message:
```protobuf
message Message {
  Kind kind = 1;
}

enum Kind {
  KIND_UNSPECIFIED = 0;
  KIND_1 = 1;
  KIND_2 = 2;
}
```

Will be compiled to the following OpenAPI spec:
```yaml
Message:
  type: object
  properties:
      kind:
          format: enum
          type: string
          enum:
              - KIND_UNSPECIFIED
              - KIND_1
              - KIND_2
```

And will be compiled to the following jsonschema spec:
```json
{
  "title": "Message",
  "$id": "http://example.com/schemas/Message.json",
  "$schema": "http://json-schema.org/draft-07/schema#",
  "type": "object",
  "properties": {
    "kind": {
      "title": "kind",
      "type": "string",
      "enum": [
        "KIND_UNSPECIFIED",
        "KIND_1",
        "KIND_2"
      ],
      "format": "enum"
    }
  }
}
```

To enable string serialization, pass the `enum_type` flag:

```bash
$ protoc sample.proto -I. --openapi_out=enum_type=string:.
```

```bash
$ protoc sample.proto -I. --jsonschema_out=enum_type=string:.
```
The existing enum behavior remains unchanged and defaults to `integer` when the `enum_type` flag is not provided.