### PR TITLE
fix ref conflict

### DIFF
--- a/cmd/protoc-gen-openapi/generator/openapi-v3.go
+++ b/cmd/protoc-gen-openapi/generator/openapi-v3.go
@@ -317,17 +317,7 @@ func getMessageName(message protoreflect.MessageDescriptor) string {
 }
 
 func (g *OpenAPIv3Generator) formatMessageName(message *protogen.Message) string {
-	name := getMessageName(message.Desc)
-
-	if *g.conf.Naming == "proto" {
-		return name
-	}
-
-	if len(name) > 0 {
-		return strings.ToUpper(name[0:1]) + name[1:]
-	}
-
-	return name
+	return fullMessageTypeName(message.Desc)
 }
 
 func (g *OpenAPIv3Generator) formatFieldName(field *protogen.Field) string {
@@ -713,9 +703,7 @@ func (g *OpenAPIv3Generator) schemaReferenceForTypeName(typeName string) string 
 		return "#/components/schemas/" + protobufValueName
 	}
 
-	parts := strings.Split(typeName, ".")
-	lastPart := parts[len(parts)-1]
-	return "#/components/schemas/" + g.formatMessageRef(lastPart)
+	return "#/components/schemas/" + g.formatMessageRef(typeName)
 }
 
 // fullMessageTypeName builds the full type name of a message.


### PR DESCRIPTION
Fixed the same schema name in different packages:
```
$ref: '#/components/schemas/Book'
->
$ref: '#/components/schemas/.library.v1.Book'
```
Example:
```
# Generated with protoc-gen-openapi
# https://github.com/google/gnostic/tree/master/cmd/protoc-gen-openapi

openapi: 3.0.3
info:
    title: Greeter API
    description: The greeting service definition.
    version: 0.0.1
paths:
    /helloworld/{name}:
        get:
            tags:
                - Greeter
            description: Sends a greeting
            operationId: Greeter_SayHello
            parameters:
                - name: name
                  in: path
                  required: true
                  schema:
                    type: string
            responses:
                "200":
                    description: OK
                    content:
                        application/json:
                            schema:
                                $ref: '#/components/schemas/.helloworld.v1.HelloReply'
components:
    schemas:
        .helloworld.v1.HelloReply:
            type: object
            properties:
                message:
                    type: string
            description: The response message containing the greetings
tags:
    - name: Greeter
```

fix #309