### PR TITLE
Remove return causing unreachable line 171

### DIFF
--- a/jsonschema/reader.go
+++ b/jsonschema/reader.go
@@ -165,7 +165,6 @@ func NewSchemaFromObject(jsonData *yaml.Node) *Schema {
 
 	default:
 		fmt.Printf("schemaValue: unexpected node %+v\n", jsonData)
-		return nil
 	}
 
 	return nil


### PR DESCRIPTION
This return breaks the pattern of default logging and the return being at the end of the method

Line 171 as is, is unreachable

The general pattern seems to be
```
	default:
		fmt.Printf("stringValue: blah)
	}
	return nil
```