### PR TITLE
[protoc-gen-openapi] Refactoring some code around

### DIFF
--- a/cmd/protoc-gen-openapi/generator/reflector.go
+++ b/cmd/protoc-gen-openapi/generator/reflector.go
@@ -1,0 +1,216 @@
+// Copyright 2020 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package generator
+
+import (
+	"log"
+	"strings"
+
+	"google.golang.org/protobuf/reflect/protoreflect"
+
+	wk "github.com/google/gnostic/cmd/protoc-gen-openapi/generator/wellknown"
+	v3 "github.com/google/gnostic/openapiv3"
+)
+
+const (
+	protobufValueName = "GoogleProtobufValue"
+	protobufAnyName   = "GoogleProtobufAny"
+)
+
+type OpenAPIv3Reflector struct {
+	conf Configuration
+
+	requiredSchemas []string // Names of schemas which are used through references.
+}
+
+// NewOpenAPIv3Reflector creates a new reflector.
+func NewOpenAPIv3Reflector(conf Configuration) *OpenAPIv3Reflector {
+	return &OpenAPIv3Reflector{
+		conf: conf,
+
+		requiredSchemas: make([]string, 0),
+	}
+}
+
+func (r *OpenAPIv3Reflector) getMessageName(message protoreflect.MessageDescriptor) string {
+	prefix := ""
+	parent := message.Parent()
+
+	if _, ok := parent.(protoreflect.MessageDescriptor); ok {
+		prefix = string(parent.Name()) + "_" + prefix
+	}
+
+	return prefix + string(message.Name())
+}
+
+func (r *OpenAPIv3Reflector) formatMessageName(message protoreflect.MessageDescriptor) string {
+	typeName := r.fullMessageTypeName(message)
+
+	name := r.getMessageName(message)
+	if !*r.conf.FQSchemaNaming {
+		if typeName == ".google.protobuf.Value" {
+			name = protobufValueName
+		} else if typeName == ".google.protobuf.Any" {
+			name = protobufAnyName
+		}
+	}
+
+	if *r.conf.Naming == "json" {
+		if len(name) > 1 {
+			name = strings.ToUpper(name[0:1]) + name[1:]
+		}
+
+		if len(name) == 1 {
+			name = strings.ToLower(name)
+		}
+	}
+
+	if *r.conf.FQSchemaNaming {
+		package_name := string(message.ParentFile().Package())
+		name = package_name + "." + name
+	}
+
+	return name
+}
+
+func (r *OpenAPIv3Reflector) formatFieldName(field protoreflect.FieldDescriptor) string {
+	if *r.conf.Naming == "proto" {
+		return string(field.Name())
+	}
+
+	return field.JSONName()
+}
+
+// fullMessageTypeName builds the full type name of a message.
+func (r *OpenAPIv3Reflector) fullMessageTypeName(message protoreflect.MessageDescriptor) string {
+	name := r.getMessageName(message)
+	return "." + string(message.ParentFile().Package()) + "." + name
+}
+
+func (r *OpenAPIv3Reflector) responseContentForMessage(message protoreflect.MessageDescriptor) (string, *v3.MediaTypes) {
+	typeName := r.fullMessageTypeName(message)
+
+	if typeName == ".google.protobuf.Empty" {
+		return "200", &v3.MediaTypes{}
+	}
+
+	if typeName == ".google.api.HttpBody" {
+		return "200", wk.NewGoogleApiHttpBodyMediaType()
+	}
+
+	return "200", wk.NewApplicationJsonMediaType(r.schemaOrReferenceForMessage(message))
+}
+
+func (r *OpenAPIv3Reflector) schemaReferenceForMessage(message protoreflect.MessageDescriptor) string {
+	typeName := r.fullMessageTypeName(message)
+	if !contains(r.requiredSchemas, typeName) {
+		r.requiredSchemas = append(r.requiredSchemas, typeName)
+	}
+	return "#/components/schemas/" + r.formatMessageName(message)
+}
+
+func (r *OpenAPIv3Reflector) schemaOrReferenceForMessage(message protoreflect.MessageDescriptor) *v3.SchemaOrReference {
+	typeName := r.fullMessageTypeName(message)
+	switch typeName {
+
+	case ".google.api.HttpBody":
+		return wk.NewGoogleApiHttpBodySchema()
+
+	case ".google.protobuf.Timestamp":
+		return wk.NewGoogleProtobufTimestampSchema()
+
+	case ".google.type.Date":
+		return wk.NewGoogleTypeDateSchema()
+
+	case ".google.type.DateTime":
+		return wk.NewGoogleTypeDateTimeSchema()
+
+	case ".google.protobuf.FieldMask":
+		return wk.NewGoogleProtobufFieldMaskSchema()
+
+	case ".google.protobuf.Struct":
+		return wk.NewGoogleProtobufStructSchema()
+
+	case ".google.protobuf.Empty":
+		// Empty is closer to JSON undefined than null, so ignore this field
+		return nil //&v3.SchemaOrReference{Oneof: &v3.SchemaOrReference_Schema{Schema: &v3.Schema{Type: "null"}}}
+
+	default:
+		ref := r.schemaReferenceForMessage(message)
+		return &v3.SchemaOrReference{
+			Oneof: &v3.SchemaOrReference_Reference{
+				Reference: &v3.Reference{XRef: ref}}}
+	}
+}
+
+func (r *OpenAPIv3Reflector) schemaOrReferenceForField(field protoreflect.FieldDescriptor) *v3.SchemaOrReference {
+	var kindSchema *v3.SchemaOrReference
+
+	kind := field.Kind()
+
+	switch kind {
+
+	case protoreflect.MessageKind:
+		if field.IsMap() {
+			// This means the field is a map, for example:
+			//   map<string, value_type> map_field = 1;
+			//
+			// The map ends up getting converted into something like this:
+			//   message MapFieldEntry {
+			//     string key = 1;
+			//     value_type value = 2;
+			//   }
+			//
+			//   repeated MapFieldEntry map_field = N;
+			//
+			// So we need to find the `value` field in the `MapFieldEntry` message and
+			// then return a MapFieldEntry schema using the schema for the `value` field
+			return wk.NewGoogleProtobufMapFieldEntrySchema(r.schemaOrReferenceForField(field.MapValue()))
+		} else {
+			kindSchema = r.schemaOrReferenceForMessage(field.Message())
+		}
+
+	case protoreflect.StringKind:
+		kindSchema = wk.NewStringSchema()
+
+	case protoreflect.Int32Kind, protoreflect.Sint32Kind, protoreflect.Uint32Kind,
+		protoreflect.Int64Kind, protoreflect.Sint64Kind, protoreflect.Uint64Kind,
+		protoreflect.Sfixed32Kind, protoreflect.Fixed32Kind, protoreflect.Sfixed64Kind,
+		protoreflect.Fixed64Kind:
+		kindSchema = wk.NewIntegerSchema(kind.String())
+
+	case protoreflect.EnumKind:
+		kindSchema = wk.NewEnumSchema(*&r.conf.EnumType, field)
+
+	case protoreflect.BoolKind:
+		kindSchema = wk.NewBooleanSchema()
+
+	case protoreflect.FloatKind, protoreflect.DoubleKind:
+		kindSchema = wk.NewNumberSchema(kind.String())
+
+	case protoreflect.BytesKind:
+		kindSchema = wk.NewBytesSchema()
+
+	default:
+		log.Printf("(TODO) Unsupported field type: %+v", r.fullMessageTypeName(field.Message()))
+	}
+
+	if field.IsList() {
+		kindSchema = wk.NewListSchema(kindSchema)
+	}
+
+	return kindSchema
+}

--- a/cmd/protoc-gen-openapi/generator/utils.go
+++ b/cmd/protoc-gen-openapi/generator/utils.go
@@ -1,0 +1,52 @@
+// Copyright 2020 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package generator
+
+import (
+	"strings"
+)
+
+// contains returns true if an array contains a specified string.
+func contains(s []string, e string) bool {
+	for _, a := range s {
+		if a == e {
+			return true
+		}
+	}
+	return false
+}
+
+// appendUnique appends a string, to a string slice, if the string is not already in the slice
+func appendUnique(s []string, e string) []string {
+	if !contains(s, e) {
+		return append(s, e)
+	}
+	return s
+}
+
+// singular produces the singular form of a collection name.
+func singular(plural string) string {
+	if strings.HasSuffix(plural, "ves") {
+		return strings.TrimSuffix(plural, "ves") + "f"
+	}
+	if strings.HasSuffix(plural, "ies") {
+		return strings.TrimSuffix(plural, "ies") + "y"
+	}
+	if strings.HasSuffix(plural, "s") {
+		return strings.TrimSuffix(plural, "s")
+	}
+	return plural
+}

--- a/cmd/protoc-gen-openapi/generator/wellknown/mediatypes.go
+++ b/cmd/protoc-gen-openapi/generator/wellknown/mediatypes.go
@@ -1,0 +1,44 @@
+// Copyright 2020 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, softwis
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package wellknown
+
+import (
+	v3 "github.com/google/gnostic/openapiv3"
+)
+
+func NewGoogleApiHttpBodyMediaType() *v3.MediaTypes {
+	return &v3.MediaTypes{
+		AdditionalProperties: []*v3.NamedMediaType{
+			{
+				Name:  "*/*",
+				Value: &v3.MediaType{},
+			},
+		},
+	}
+}
+
+func NewApplicationJsonMediaType(schema *v3.SchemaOrReference) *v3.MediaTypes {
+	return &v3.MediaTypes{
+		AdditionalProperties: []*v3.NamedMediaType{
+			{
+				Name: "application/json",
+				Value: &v3.MediaType{
+					Schema: schema,
+				},
+			},
+		},
+	}
+}

--- a/cmd/protoc-gen-openapi/generator/wellknown/schemas.go
+++ b/cmd/protoc-gen-openapi/generator/wellknown/schemas.go
@@ -1,0 +1,191 @@
+// Copyright 2020 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, softwis
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package wellknown
+
+import (
+	v3 "github.com/google/gnostic/openapiv3"
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+func NewStringSchema() *v3.SchemaOrReference {
+	return &v3.SchemaOrReference{
+		Oneof: &v3.SchemaOrReference_Schema{
+			Schema: &v3.Schema{Type: "string"}}}
+}
+
+func NewBooleanSchema() *v3.SchemaOrReference {
+	return &v3.SchemaOrReference{
+		Oneof: &v3.SchemaOrReference_Schema{
+			Schema: &v3.Schema{Type: "boolean"}}}
+}
+
+func NewBytesSchema() *v3.SchemaOrReference {
+	return &v3.SchemaOrReference{
+		Oneof: &v3.SchemaOrReference_Schema{
+			Schema: &v3.Schema{Type: "string", Format: "bytes"}}}
+}
+
+func NewIntegerSchema(format string) *v3.SchemaOrReference {
+	return &v3.SchemaOrReference{
+		Oneof: &v3.SchemaOrReference_Schema{
+			Schema: &v3.Schema{Type: "integer", Format: format}}}
+}
+
+func NewNumberSchema(format string) *v3.SchemaOrReference {
+	return &v3.SchemaOrReference{
+		Oneof: &v3.SchemaOrReference_Schema{
+			Schema: &v3.Schema{Type: "number", Format: format}}}
+}
+
+func NewEnumSchema(enum_type *string, field protoreflect.FieldDescriptor) *v3.SchemaOrReference {
+	schema := &v3.Schema{Format: "enum"}
+	if enum_type != nil && *enum_type == "string" {
+		schema.Type = "string"
+		schema.Enum = make([]*v3.Any, 0, field.Enum().Values().Len())
+		for i := 0; i < field.Enum().Values().Len(); i++ {
+			schema.Enum = append(schema.Enum, &v3.Any{
+				Yaml: string(field.Enum().Values().Get(i).Name()),
+			})
+		}
+	} else {
+		schema.Type = "integer"
+	}
+	return &v3.SchemaOrReference{
+		Oneof: &v3.SchemaOrReference_Schema{
+			Schema: schema}}
+}
+
+func NewListSchema(item_schema *v3.SchemaOrReference) *v3.SchemaOrReference {
+	return &v3.SchemaOrReference{
+		Oneof: &v3.SchemaOrReference_Schema{
+			Schema: &v3.Schema{
+				Type:  "array",
+				Items: &v3.ItemsItem{SchemaOrReference: []*v3.SchemaOrReference{item_schema}},
+			},
+		},
+	}
+}
+
+// google.api.HttpBody will contain POST body data
+// This is based on how Envoy handles google.api.HttpBody
+func NewGoogleApiHttpBodySchema() *v3.SchemaOrReference {
+	return &v3.SchemaOrReference{
+		Oneof: &v3.SchemaOrReference_Schema{
+			Schema: &v3.Schema{Type: "string"}}}
+}
+
+// google.protobuf.Timestamp is serialized as a string
+func NewGoogleProtobufTimestampSchema() *v3.SchemaOrReference {
+	return &v3.SchemaOrReference{
+		Oneof: &v3.SchemaOrReference_Schema{
+			Schema: &v3.Schema{Type: "string", Format: "RFC3339"}}}
+}
+
+// google.type.Date is serialized as a string
+func NewGoogleTypeDateSchema() *v3.SchemaOrReference {
+	return &v3.SchemaOrReference{
+		Oneof: &v3.SchemaOrReference_Schema{
+			Schema: &v3.Schema{Type: "string", Format: "date"}}}
+}
+
+// google.type.DateTime is serialized as a string
+func NewGoogleTypeDateTimeSchema() *v3.SchemaOrReference {
+	return &v3.SchemaOrReference{
+		Oneof: &v3.SchemaOrReference_Schema{
+			Schema: &v3.Schema{Type: "string", Format: "date-time"}}}
+}
+
+// google.protobuf.FieldMask masks is serialized as a string
+func NewGoogleProtobufFieldMaskSchema() *v3.SchemaOrReference {
+	return &v3.SchemaOrReference{
+		Oneof: &v3.SchemaOrReference_Schema{
+			Schema: &v3.Schema{Type: "string", Format: "field-mask"}}}
+}
+
+// google.protobuf.Struct is equivalent to a JSON object
+func NewGoogleProtobufStructSchema() *v3.SchemaOrReference {
+	return &v3.SchemaOrReference{
+		Oneof: &v3.SchemaOrReference_Schema{
+			Schema: &v3.Schema{Type: "object"}}}
+}
+
+// google.protobuf.Value is handled specially
+// See here for the details on the JSON mapping:
+//   https://developers.google.com/protocol-buffers/docs/proto3#json
+// and here:
+//   https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Value
+func NewGoogleProtobufValueSchema(name string) *v3.NamedSchemaOrReference {
+	return &v3.NamedSchemaOrReference{
+		Name: name,
+		Value: &v3.SchemaOrReference{
+			Oneof: &v3.SchemaOrReference_Schema{
+				Schema: &v3.Schema{
+					Description: "Represents a dynamically typed value which can be either null, a number, a string, a boolean, a recursive struct value, or a list of values.",
+				},
+			},
+		},
+	}
+}
+
+// google.protobuf.Any is handled specially
+// See here for the details on the JSON mapping:
+//   https://developers.google.com/protocol-buffers/docs/proto3#json
+func NewGoogleProtobufAnySchema(name string) *v3.NamedSchemaOrReference {
+	return &v3.NamedSchemaOrReference{
+		Name: name,
+		Value: &v3.SchemaOrReference{
+			Oneof: &v3.SchemaOrReference_Schema{
+				Schema: &v3.Schema{
+					Type:        "object",
+					Description: "Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.",
+					Properties: &v3.Properties{
+						AdditionalProperties: []*v3.NamedSchemaOrReference{
+							{
+								Name: "@type",
+								Value: &v3.SchemaOrReference{
+									Oneof: &v3.SchemaOrReference_Schema{
+										Schema: &v3.Schema{
+											Type: "string",
+										},
+									},
+								},
+							},
+						},
+					},
+					AdditionalProperties: &v3.AdditionalPropertiesItem{
+						Oneof: &v3.AdditionalPropertiesItem_Boolean{
+							Boolean: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func NewGoogleProtobufMapFieldEntrySchema(value_field_schema *v3.SchemaOrReference) *v3.SchemaOrReference {
+	return &v3.SchemaOrReference{
+		Oneof: &v3.SchemaOrReference_Schema{
+			Schema: &v3.Schema{Type: "object",
+				AdditionalProperties: &v3.AdditionalPropertiesItem{
+					Oneof: &v3.AdditionalPropertiesItem_SchemaOrReference{
+						SchemaOrReference: value_field_schema,
+					},
+				},
+			},
+		},
+	}
+}

--- a/cmd/protoc-gen-openapi/main.go
+++ b/cmd/protoc-gen-openapi/main.go
@@ -31,7 +31,7 @@ func main() {
 		Title:          flags.String("title", "", "name of the API"),
 		Description:    flags.String("description", "", "description of the API"),
 		Naming:         flags.String("naming", "json", `naming convention. Use "proto" for passing names directly from the proto files`),
-		FQSchemaNaming: flags.Bool("fq_schema_naming", false, `schema naming convention. If "true" prefixes the schema name with the proto message package name`),
+		FQSchemaNaming: flags.Bool("fq_schema_naming", false, `schema naming convention. If "true", generates fully-qualified schema names by prefixing them with the proto message package name`),
 		EnumType:       flags.String("enum_type", "integer", `type for enum serialization. Use "string" for string-based serialization`),
 		CircularDepth:  flags.Int("depth", 2, "depth of recursion for circular messages"),
 	}


### PR DESCRIPTION
First, this is based off of my previous PR #327 so this PR shows some of the changes in that PR too. If you want to see just the changes in this PR you can look at this compare here:
https://github.com/jeffsawatzky/gnostic/compare/grpc-status...jeffsawatzky:refactoring

# Purpose
- the code in the protoc-gen-openapi project was all in one file and it was hard for me to locate stuff. I tried moving the code around a bit to separate it a little and hopefully make it a bit easier to digest.

1) Most of the schemas and media types for well known things were moved to a `wellknown` files
2) The code that takes `protoreflect` descriptors and returns schemas based on those descriptors was moved into a `reflector` file
3) All the remaining code that operates on the `protogen` classes stayed in the `generator` file
4) I also put some of the util functions into a `utils` file

So the basic flow is:
- `protoc` passes `protogen` stuff to the `generator`
- the `generator` takes the `protoreflect` descriptors and passes them to the `reflector`
- the `reflector` decides what kind of schema it needs to return, and uses the `wellknown` ones when it is for a known message type.

There is still some stuff to clean up, but with these base files in place it will be easier to do so.

Other than that no new functionality was introduced in this PR and all of the existing tests continue to pass without any modifications.

@timburks / @morphar thoughts?