### PR TITLE
[openapiv3 annotations.proto] Use a Registered Extension Number

### DIFF
--- a/openapiv3/annotations.proto
+++ b/openapiv3/annotations.proto
@@ -44,17 +44,17 @@ option objc_class_prefix = "OAS";
 option go_package = "./openapiv3;openapi_v3";
 
 extend google.protobuf.FileOptions {
-  Document document = 1042;
+  Document document = 1143;
 }
 
 extend google.protobuf.MethodOptions {
-  Operation operation = 1042;
+  Operation operation = 1143;
 }
 
 extend google.protobuf.MessageOptions {
-  Schema schema = 1042;
+  Schema schema = 1143;
 }
 
 extend google.protobuf.FieldOptions {
-  Schema property = 1042;
+  Schema property = 1143;
 }


### PR DESCRIPTION
We are currently using `1042` for the extension number, which is currently ["registered"](https://github.com/protocolbuffers/protobuf/blob/main/docs/options.md) for protoc-gen-openapiv2 from the grpc-gateway project. I have created a PR to create a new registered extension number for gnostic [here](https://github.com/protocolbuffers/protobuf/pull/9754/files).

And this PR updates the extension number gnostic uses to the one registered in that PR.

@timburks not sure if you have any "pull" over in the protobuf repo to get that PR approved and merged?