### PR TITLE
metrics/vocabulary: err check before Close()

### DIFF
--- a/metrics/vocabulary/vocabulary.go
+++ b/metrics/vocabulary/vocabulary.go
@@ -43,10 +43,11 @@ func WriteCSV(v *metrics.Vocabulary, filename string) error {
 		filename = "vocabulary-operation.csv"
 	}
 	f4, ferror := os.Create(filename)
-	defer f4.Close()
 	if ferror != nil {
 		return ferror
 	}
+	defer f4.Close()
+
 	for _, s := range v.Schemas {
 		temp := fmt.Sprintf("%s,\"%s\",%d\n", "schemas", s.Word, int(s.Count))
 		f4.WriteString(temp)


### PR DESCRIPTION
This ensures that a check of `err` happens before a deferred `Close()`.