### PR TITLE
plugins/gnostic-analyze/summarize: fix dropped error

### DIFF
--- a/plugins/gnostic-analyze/summarize/main.go
+++ b/plugins/gnostic-analyze/summarize/main.go
@@ -32,6 +32,9 @@ var stats []statistics.DocumentStatistics
 
 // walker is called for each summary file found.
 func walker(p string, info os.FileInfo, err error) error {
+	if err != nil {
+		return err
+	}
 	basename := path.Base(p)
 	if basename != "summary.json" {
 		return nil


### PR DESCRIPTION
This picks up an `err` variable that was being passed into a walker function and then ignored.