### PR TITLE
feat: option to disable adding tag with service name (#363)

### DIFF
--- a/cmd/protoc-gen-openapi/examples/google/example/library/v1/openapi_disable_service_tags.yaml
+++ b/cmd/protoc-gen-openapi/examples/google/example/library/v1/openapi_disable_service_tags.yaml
@@ -1,0 +1,515 @@
+# Generated with protoc-gen-openapi
+# https://github.com/google/gnostic/tree/master/cmd/protoc-gen-openapi
+
+openapi: 3.0.3
+info:
+    title: ""
+    version: 0.0.1
+servers:
+    - url: https://library-example.googleapis.com
+paths:
+    /v1/shelves:
+        get:
+            description: |-
+                Lists shelves. The order is unspecified but deterministic. Newly created
+                 shelves will not necessarily be added to the end of this list.
+            operationId: LibraryService_ListShelves
+            parameters:
+                - name: pageSize
+                  in: query
+                  description: |-
+                    Requested page size. Server may return fewer shelves than requested.
+                     If unspecified, server will pick an appropriate default.
+                  schema:
+                    type: integer
+                    format: int32
+                - name: pageToken
+                  in: query
+                  description: |-
+                    A token identifying a page of results the server should return.
+                     Typically, this is the value of
+                     [ListShelvesResponse.next_page_token][google.example.library.v1.ListShelvesResponse.next_page_token]
+                     returned from the previous call to `ListShelves` method.
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ListShelvesResponse'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+        post:
+            description: Creates a shelf, and returns the new Shelf.
+            operationId: LibraryService_CreateShelf
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/Shelf'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Shelf'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/shelves/{shelf}:
+        get:
+            description: Gets a shelf. Returns NOT_FOUND if the shelf does not exist.
+            operationId: LibraryService_GetShelf
+            parameters:
+                - name: shelf
+                  in: path
+                  description: The shelf id.
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Shelf'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+        delete:
+            description: Deletes a shelf. Returns NOT_FOUND if the shelf does not exist.
+            operationId: LibraryService_DeleteShelf
+            parameters:
+                - name: shelf
+                  in: path
+                  description: The shelf id.
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content: {}
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/shelves/{shelf}/books:
+        get:
+            description: |-
+                Lists books in a shelf. The order is unspecified but deterministic. Newly
+                 created books will not necessarily be added to the end of this list.
+                 Returns NOT_FOUND if the shelf does not exist.
+            operationId: LibraryService_ListBooks
+            parameters:
+                - name: shelf
+                  in: path
+                  description: The shelf id.
+                  required: true
+                  schema:
+                    type: string
+                - name: pageSize
+                  in: query
+                  description: |-
+                    Requested page size. Server may return fewer books than requested.
+                     If unspecified, server will pick an appropriate default.
+                  schema:
+                    type: integer
+                    format: int32
+                - name: pageToken
+                  in: query
+                  description: |-
+                    A token identifying a page of results the server should return.
+                     Typically, this is the value of
+                     [ListBooksResponse.next_page_token][google.example.library.v1.ListBooksResponse.next_page_token].
+                     returned from the previous call to `ListBooks` method.
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ListBooksResponse'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+        post:
+            description: Creates a book, and returns the new Book.
+            operationId: LibraryService_CreateBook
+            parameters:
+                - name: shelf
+                  in: path
+                  description: The shelf id.
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/Book'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Book'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/shelves/{shelf}/books/{book}:
+        get:
+            description: Gets a book. Returns NOT_FOUND if the book does not exist.
+            operationId: LibraryService_GetBook
+            parameters:
+                - name: shelf
+                  in: path
+                  description: The shelf id.
+                  required: true
+                  schema:
+                    type: string
+                - name: book
+                  in: path
+                  description: The book id.
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Book'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+        put:
+            description: |-
+                Updates a book. Returns INVALID_ARGUMENT if the name of the book
+                 is non-empty and does not equal the existing name.
+            operationId: LibraryService_UpdateBook
+            parameters:
+                - name: shelf
+                  in: path
+                  description: The shelf id.
+                  required: true
+                  schema:
+                    type: string
+                - name: book
+                  in: path
+                  description: The book id.
+                  required: true
+                  schema:
+                    type: string
+                - name: name
+                  in: query
+                  description: The name of the book to update.
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/Book'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Book'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+        delete:
+            description: Deletes a book. Returns NOT_FOUND if the book does not exist.
+            operationId: LibraryService_DeleteBook
+            parameters:
+                - name: shelf
+                  in: path
+                  description: The shelf id.
+                  required: true
+                  schema:
+                    type: string
+                - name: book
+                  in: path
+                  description: The book id.
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content: {}
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/shelves/{shelf}/books/{book}:move:
+        post:
+            description: |-
+                Moves a book to another shelf, and returns the new book. The book
+                 id of the new book may not be the same as the original book.
+            operationId: LibraryService_MoveBook
+            parameters:
+                - name: shelf
+                  in: path
+                  description: The shelf id.
+                  required: true
+                  schema:
+                    type: string
+                - name: book
+                  in: path
+                  description: The book id.
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/MoveBookRequest'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Book'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/shelves/{shelf}:merge:
+        post:
+            description: |-
+                Merges two shelves by adding all books from the shelf named
+                 `other_shelf_name` to shelf `name`, and deletes
+                 `other_shelf_name`. Returns the updated shelf.
+                 The book ids of the moved books may not be the same as the original books.
+
+                 Returns NOT_FOUND if either shelf does not exist.
+                 This call is a no-op if the specified shelves are the same.
+            operationId: LibraryService_MergeShelves
+            parameters:
+                - name: shelf
+                  in: path
+                  description: The shelf id.
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/MergeShelvesRequest'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Shelf'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+components:
+    schemas:
+        Book:
+            required:
+                - name
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: |-
+                        The resource name of the book.
+                         Book names have the form `shelves/{shelf_id}/books/{book_id}`.
+                         The name is ignored when creating a book.
+                author:
+                    type: string
+                    description: The name of the book author.
+                title:
+                    type: string
+                    description: The title of the book.
+                read:
+                    type: boolean
+                    description: Value indicating whether the book has been read.
+                borrowTime:
+                    readOnly: true
+                    type: string
+                    description: The previous borrowing timestamp.
+                    format: date-time
+                createdAt:
+                    readOnly: true
+                    type: string
+                    description: The creation date and time.
+                    format: date-time
+                updatedAt:
+                    readOnly: true
+                    type: string
+                    description: The last update date and time.
+                    format: date-time
+            description: A single book in the library.
+        GoogleProtobufAny:
+            type: object
+            properties:
+                '@type':
+                    type: string
+                    description: The type of the serialized message.
+            additionalProperties: true
+            description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
+        ListBooksResponse:
+            type: object
+            properties:
+                books:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Book'
+                    description: The list of books.
+                nextPageToken:
+                    type: string
+                    description: |-
+                        A token to retrieve next page of results.
+                         Pass this value in the
+                         [ListBooksRequest.page_token][google.example.library.v1.ListBooksRequest.page_token]
+                         field in the subsequent call to `ListBooks` method to retrieve the next
+                         page of results.
+            description: Response message for LibraryService.ListBooks.
+        ListShelvesResponse:
+            type: object
+            properties:
+                shelves:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Shelf'
+                    description: The list of shelves.
+                nextPageToken:
+                    type: string
+                    description: |-
+                        A token to retrieve next page of results.
+                         Pass this value in the
+                         [ListShelvesRequest.page_token][google.example.library.v1.ListShelvesRequest.page_token]
+                         field in the subsequent call to `ListShelves` method to retrieve the next
+                         page of results.
+            description: Response message for LibraryService.ListShelves.
+        MergeShelvesRequest:
+            required:
+                - name
+                - otherShelfName
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: The name of the shelf we're adding books to.
+                otherShelfName:
+                    type: string
+                    description: The name of the shelf we're removing books from and deleting.
+            description: |-
+                Describes the shelf being removed (other_shelf_name) and updated
+                 (name) in this merge.
+        MoveBookRequest:
+            required:
+                - name
+                - otherShelfName
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: The name of the book to move.
+                otherShelfName:
+                    type: string
+                    description: The name of the destination shelf.
+            description: |-
+                Describes what book to move (name) and what shelf we're moving it
+                 to (other_shelf_name).
+        Shelf:
+            required:
+                - name
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: |-
+                        The resource name of the shelf.
+                         Shelf names have the form `shelves/{shelf_id}`.
+                         The name is ignored when creating a shelf.
+                theme:
+                    type: string
+                    description: The theme of the shelf
+                nextSortAt:
+                    readOnly: true
+                    type: string
+                    description: The next sorting date.
+                    format: date
+                createdAt:
+                    readOnly: true
+                    type: string
+                    description: The creation date and time.
+                    format: date-time
+                updatedAt:
+                    readOnly: true
+                    type: string
+                    description: The last update date and time.
+                    format: date-time
+            description: A Shelf contains a collection of books with a theme.
+        Status:
+            type: object
+            properties:
+                code:
+                    type: integer
+                    description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
+                    format: int32
+                message:
+                    type: string
+                    description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
+                details:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/GoogleProtobufAny'
+                    description: A list of messages that carry the error details.  There is a common set of message types for APIs to use.
+            description: 'The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors).'

--- a/cmd/protoc-gen-openapi/examples/tests/additional_bindings/openapi_disable_service_tags.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/additional_bindings/openapi_disable_service_tags.yaml
@@ -1,0 +1,91 @@
+# Generated with protoc-gen-openapi
+# https://github.com/google/gnostic/tree/master/cmd/protoc-gen-openapi
+
+openapi: 3.0.3
+info:
+    title: ""
+    version: 0.0.1
+paths:
+    /v1/messages:
+        patch:
+            operationId: Messaging_UpdateMessage
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/Message'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Message'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/messages/{messageId}:
+        patch:
+            operationId: Messaging_UpdateMessage
+            parameters:
+                - name: messageId
+                  in: path
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            type: string
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Message'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+components:
+    schemas:
+        GoogleProtobufAny:
+            type: object
+            properties:
+                '@type':
+                    type: string
+                    description: The type of the serialized message.
+            additionalProperties: true
+            description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
+        Message:
+            type: object
+            properties:
+                messageId:
+                    type: string
+                text:
+                    type: string
+        Status:
+            type: object
+            properties:
+                code:
+                    type: integer
+                    description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
+                    format: int32
+                message:
+                    type: string
+                    description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
+                details:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/GoogleProtobufAny'
+                    description: A list of messages that carry the error details.  There is a common set of message types for APIs to use.
+            description: 'The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors).'

--- a/cmd/protoc-gen-openapi/examples/tests/allofwrap/openapi_disable_service_tags.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/allofwrap/openapi_disable_service_tags.yaml
@@ -1,0 +1,90 @@
+# Generated with protoc-gen-openapi
+# https://github.com/google/gnostic/tree/master/cmd/protoc-gen-openapi
+
+openapi: 3.0.3
+info:
+    title: ""
+    version: 0.0.1
+paths:
+    /v1/messages/{message_id}:
+        patch:
+            operationId: Messaging_UpdateMessage
+            parameters:
+                - name: message_id
+                  in: path
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/Message'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Message'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+components:
+    schemas:
+        GoogleProtobufAny:
+            type: object
+            properties:
+                '@type':
+                    type: string
+                    description: The type of the serialized message.
+            additionalProperties: true
+            description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
+        Message:
+            type: object
+            properties:
+                sub:
+                    $ref: '#/components/schemas/Message_Sub'
+                subInput:
+                    writeOnly: true
+                    allOf:
+                        - $ref: '#/components/schemas/Message_Sub'
+                subOutput:
+                    readOnly: true
+                    allOf:
+                        - $ref: '#/components/schemas/Message_Sub'
+                subDesc:
+                    allOf:
+                        - $ref: '#/components/schemas/Message_Sub'
+                    description: this sub has a description
+                subs:
+                    readOnly: true
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Message_Sub'
+                    description: test repeated, should not allof wrapped
+        Message_Sub:
+            type: object
+            properties:
+                content:
+                    type: string
+        Status:
+            type: object
+            properties:
+                code:
+                    type: integer
+                    description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
+                    format: int32
+                message:
+                    type: string
+                    description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
+                details:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/GoogleProtobufAny'
+                    description: A list of messages that carry the error details.  There is a common set of message types for APIs to use.
+            description: 'The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors).'

--- a/cmd/protoc-gen-openapi/examples/tests/bodymapping/openapi_disable_service_tags.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/bodymapping/openapi_disable_service_tags.yaml
@@ -1,0 +1,69 @@
+# Generated with protoc-gen-openapi
+# https://github.com/google/gnostic/tree/master/cmd/protoc-gen-openapi
+
+openapi: 3.0.3
+info:
+    title: ""
+    version: 0.0.1
+paths:
+    /v1/messages/{messageId}:
+        patch:
+            operationId: Messaging_UpdateMessage
+            parameters:
+                - name: messageId
+                  in: path
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            type: string
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Message'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+components:
+    schemas:
+        GoogleProtobufAny:
+            type: object
+            properties:
+                '@type':
+                    type: string
+                    description: The type of the serialized message.
+            additionalProperties: true
+            description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
+        Message:
+            type: object
+            properties:
+                messageId:
+                    type: string
+                text:
+                    type: string
+        Status:
+            type: object
+            properties:
+                code:
+                    type: integer
+                    description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
+                    format: int32
+                message:
+                    type: string
+                    description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
+                details:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/GoogleProtobufAny'
+                    description: A list of messages that carry the error details.  There is a common set of message types for APIs to use.
+            description: 'The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors).'

--- a/cmd/protoc-gen-openapi/examples/tests/enumoptions/openapi_disable_service_tags.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/enumoptions/openapi_disable_service_tags.yaml
@@ -1,0 +1,71 @@
+# Generated with protoc-gen-openapi
+# https://github.com/google/gnostic/tree/master/cmd/protoc-gen-openapi
+
+openapi: 3.0.3
+info:
+    title: ""
+    version: 0.0.1
+paths:
+    /v1/messages/{message_id}:
+        post:
+            operationId: Messaging_CreateMessage
+            parameters:
+                - name: message_id
+                  in: path
+                  required: true
+                  schema:
+                    type: string
+                - name: kind
+                  in: query
+                  schema:
+                    type: integer
+                    format: enum
+            requestBody:
+                content:
+                    application/json: {}
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Message'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+components:
+    schemas:
+        GoogleProtobufAny:
+            type: object
+            properties:
+                '@type':
+                    type: string
+                    description: The type of the serialized message.
+            additionalProperties: true
+            description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
+        Message:
+            type: object
+            properties:
+                kind:
+                    type: integer
+                    format: enum
+        Status:
+            type: object
+            properties:
+                code:
+                    type: integer
+                    description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
+                    format: int32
+                message:
+                    type: string
+                    description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
+                details:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/GoogleProtobufAny'
+                    description: A list of messages that carry the error details.  There is a common set of message types for APIs to use.
+            description: 'The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors).'

--- a/cmd/protoc-gen-openapi/examples/tests/jsonoptions/openapi_disable_service_tags.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/jsonoptions/openapi_disable_service_tags.yaml
@@ -1,0 +1,116 @@
+# Generated with protoc-gen-openapi
+# https://github.com/google/gnostic/tree/master/cmd/protoc-gen-openapi
+
+openapi: 3.0.3
+info:
+    title: ""
+    version: 0.0.1
+paths:
+    /v1/messages/{messageId}:
+        post:
+            operationId: Messaging_CreateMessage
+            parameters:
+                - name: messageId
+                  in: path
+                  required: true
+                  schema:
+                    type: string
+                - name: notUsed
+                  in: query
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            type: string
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Message'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/messages/{message_id}:
+        patch:
+            operationId: Messaging_UpdateMessage
+            parameters:
+                - name: message_id
+                  in: path
+                  required: true
+                  schema:
+                    type: string
+                - name: not_used
+                  in: query
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            type: string
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Message2'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+components:
+    schemas:
+        GoogleProtobufAny:
+            type: object
+            properties:
+                '@type':
+                    type: string
+                    description: The type of the serialized message.
+            additionalProperties: true
+            description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
+        Message:
+            type: object
+            properties:
+                messageId:
+                    type: string
+                bodyText:
+                    type: string
+                notUsed:
+                    type: string
+        Message2:
+            type: object
+            properties:
+                message_id:
+                    type: string
+                body_text:
+                    type: string
+                not_used:
+                    type: string
+        Status:
+            type: object
+            properties:
+                code:
+                    type: integer
+                    description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
+                    format: int32
+                message:
+                    type: string
+                    description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
+                details:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/GoogleProtobufAny'
+                    description: A list of messages that carry the error details.  There is a common set of message types for APIs to use.
+            description: 'The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors).'

--- a/cmd/protoc-gen-openapi/examples/tests/mapfields/openapi_disable_service_tags.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/mapfields/openapi_disable_service_tags.yaml
@@ -1,0 +1,109 @@
+# Generated with protoc-gen-openapi
+# https://github.com/google/gnostic/tree/master/cmd/protoc-gen-openapi
+
+openapi: 3.0.3
+info:
+    title: ""
+    version: 0.0.1
+paths:
+    /v1/messages/{messageId}:
+        patch:
+            operationId: Messaging_UpdateMessage
+            parameters:
+                - name: messageId
+                  in: path
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/Message'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Message'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+components:
+    schemas:
+        AnotherMessage:
+            type: object
+            properties:
+                id:
+                    type: string
+                label:
+                    type: string
+        GoogleProtobufAny:
+            type: object
+            properties:
+                '@type':
+                    type: string
+                    description: The type of the serialized message.
+            additionalProperties: true
+            description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
+        Message:
+            type: object
+            properties:
+                messageId:
+                    type: string
+                anotherMessage:
+                    $ref: '#/components/schemas/AnotherMessage'
+                subMessage:
+                    $ref: '#/components/schemas/Message_SubMessage'
+                stringList:
+                    type: array
+                    items:
+                        type: string
+                subMessageList:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Message_SubMessage'
+                objectList:
+                    type: array
+                    items:
+                        type: object
+                stringsMap:
+                    type: object
+                    additionalProperties:
+                        type: string
+                subMessagesMap:
+                    type: object
+                    additionalProperties:
+                        $ref: '#/components/schemas/Message_SubMessage'
+                objectsMap:
+                    type: object
+                    additionalProperties:
+                        type: object
+        Message_SubMessage:
+            type: object
+            properties:
+                id:
+                    type: string
+                label:
+                    type: string
+        Status:
+            type: object
+            properties:
+                code:
+                    type: integer
+                    description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
+                    format: int32
+                message:
+                    type: string
+                    description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
+                details:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/GoogleProtobufAny'
+                    description: A list of messages that carry the error details.  There is a common set of message types for APIs to use.
+            description: 'The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors).'

--- a/cmd/protoc-gen-openapi/examples/tests/noannotations/openapi_disable_service_tags.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/noannotations/openapi_disable_service_tags.yaml
@@ -1,0 +1,69 @@
+# Generated with protoc-gen-openapi
+# https://github.com/google/gnostic/tree/master/cmd/protoc-gen-openapi
+
+openapi: 3.0.3
+info:
+    title: ""
+    version: 0.0.1
+paths:
+    /v1/messages/{message_id}:
+        patch:
+            operationId: Messaging1_UpdateMessage
+            parameters:
+                - name: message_id
+                  in: path
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/Message'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Message'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+components:
+    schemas:
+        GoogleProtobufAny:
+            type: object
+            properties:
+                '@type':
+                    type: string
+                    description: The type of the serialized message.
+            additionalProperties: true
+            description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
+        Message:
+            type: object
+            properties:
+                id:
+                    type: string
+                label:
+                    type: string
+        Status:
+            type: object
+            properties:
+                code:
+                    type: integer
+                    description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
+                    format: int32
+                message:
+                    type: string
+                    description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
+                details:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/GoogleProtobufAny'
+                    description: A list of messages that carry the error details.  There is a common set of message types for APIs to use.
+            description: 'The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors).'

--- a/cmd/protoc-gen-openapi/examples/tests/openapiv3annotations/openapi_disable_service_tags.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/openapiv3annotations/openapi_disable_service_tags.yaml
@@ -1,0 +1,86 @@
+# Generated with protoc-gen-openapi
+# https://github.com/google/gnostic/tree/master/cmd/protoc-gen-openapi
+
+openapi: 3.0.3
+info:
+    title: Title from annotation
+    description: Description from annotation
+    contact:
+        name: Contact Name
+        url: https://github.com/google/gnostic
+        email: gnostic@google.com
+    license:
+        name: Apache License
+        url: https://github.com/google/gnostic/blob/master/LICENSE
+    version: Version from annotation
+paths:
+    /v1/messages/{message_id}:
+        patch:
+            operationId: Messaging1_UpdateMessage
+            parameters:
+                - name: message_id
+                  in: path
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/Message'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Message'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+            security:
+                - BasicAuth: []
+components:
+    schemas:
+        GoogleProtobufAny:
+            type: object
+            properties:
+                '@type':
+                    type: string
+                    description: The type of the serialized message.
+            additionalProperties: true
+            description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
+        Message:
+            title: This is an overridden message schema title
+            type: object
+            properties:
+                id:
+                    type: string
+                label:
+                    title: this is an overriden field schema title
+                    maxLength: 255
+                    type: string
+        Status:
+            type: object
+            properties:
+                code:
+                    type: integer
+                    description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
+                    format: int32
+                message:
+                    type: string
+                    description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
+                details:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/GoogleProtobufAny'
+                    description: A list of messages that carry the error details.  There is a common set of message types for APIs to use.
+            description: 'The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors).'
+    securitySchemes:
+        BasicAuth:
+            type: http
+            scheme: basic

--- a/cmd/protoc-gen-openapi/examples/tests/pathparams/openapi_disable_service_tags.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/pathparams/openapi_disable_service_tags.yaml
@@ -1,0 +1,125 @@
+# Generated with protoc-gen-openapi
+# https://github.com/google/gnostic/tree/master/cmd/protoc-gen-openapi
+
+openapi: 3.0.3
+info:
+    title: ""
+    version: 0.0.1
+paths:
+    /v1/messages/{messageId}:
+        get:
+            operationId: Messaging_GetMessage
+            parameters:
+                - name: messageId
+                  in: path
+                  required: true
+                  schema:
+                    type: string
+                - name: userId
+                  in: query
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Message'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+        post:
+            operationId: Messaging_CreateMessage
+            parameters:
+                - name: messageId
+                  in: path
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/Message'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Message'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/users/{userId}/messages/{messageId}:
+        get:
+            operationId: Messaging_GetUserMessage
+            parameters:
+                - name: userId
+                  in: path
+                  required: true
+                  schema:
+                    type: string
+                - name: messageId
+                  in: path
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Message'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+components:
+    schemas:
+        GoogleProtobufAny:
+            type: object
+            properties:
+                '@type':
+                    type: string
+                    description: The type of the serialized message.
+            additionalProperties: true
+            description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
+        Message:
+            type: object
+            properties:
+                messageId:
+                    type: string
+                userId:
+                    type: string
+                content:
+                    type: string
+                maybe:
+                    type: string
+        Status:
+            type: object
+            properties:
+                code:
+                    type: integer
+                    description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
+                    format: int32
+                message:
+                    type: string
+                    description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
+                details:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/GoogleProtobufAny'
+                    description: A list of messages that carry the error details.  There is a common set of message types for APIs to use.
+            description: 'The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors).'

--- a/cmd/protoc-gen-openapi/examples/tests/protobuftypes/openapi_disable_service_tags.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/protobuftypes/openapi_disable_service_tags.yaml
@@ -1,0 +1,503 @@
+# Generated with protoc-gen-openapi
+# https://github.com/google/gnostic/tree/master/cmd/protoc-gen-openapi
+
+openapi: 3.0.3
+info:
+    title: ""
+    version: 0.0.1
+servers:
+    - url: https://foo.googleapi.com
+paths:
+    /v1/messages:
+        get:
+            operationId: Messaging_ListMessages
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/GoogleProtobufValue'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/messages/{messageId}:
+        get:
+            operationId: Messaging_GetMessage
+            parameters:
+                - name: messageId
+                  in: path
+                  required: true
+                  schema:
+                    type: string
+                - name: stringType
+                  in: query
+                  schema:
+                    type: string
+                - name: recursiveType.parentId
+                  in: query
+                  schema:
+                    type: integer
+                    format: int32
+                - name: recursiveType.child.childId
+                  in: query
+                  schema:
+                    type: integer
+                    format: int32
+                - name: recursiveType.child.parent.parentId
+                  in: query
+                  schema:
+                    type: integer
+                    format: int32
+                - name: recursiveType.child.parent.child.childId
+                  in: query
+                  schema:
+                    type: integer
+                    format: int32
+                - name: embeddedType.messageId
+                  in: query
+                  schema:
+                    type: string
+                - name: subType.messageId
+                  in: query
+                  schema:
+                    type: string
+                - name: subType.subSubMessage.messageId
+                  in: query
+                  schema:
+                    type: string
+                - name: subType.subSubMessage.integers
+                  in: query
+                  schema:
+                    type: array
+                    items:
+                        type: integer
+                        format: int32
+                - name: repeatedType
+                  in: query
+                  schema:
+                    type: array
+                    items:
+                        type: string
+                - name: valueType
+                  in: query
+                  description: Description of value
+                  schema:
+                    $ref: '#/components/schemas/GoogleProtobufValue'
+                - name: repeatedValueType
+                  in: query
+                  description: Description of repeated value
+                  schema:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/GoogleProtobufValue'
+                - name: boolValueType
+                  in: query
+                  schema:
+                    type: boolean
+                - name: bytesValueType
+                  in: query
+                  schema:
+                    type: string
+                    format: bytes
+                - name: int32ValueType
+                  in: query
+                  schema:
+                    type: integer
+                    format: int32
+                - name: uint32ValueType
+                  in: query
+                  schema:
+                    type: integer
+                    format: uint32
+                - name: stringValueType
+                  in: query
+                  schema:
+                    type: string
+                - name: int64ValueType
+                  in: query
+                  schema:
+                    type: string
+                - name: uint64ValueType
+                  in: query
+                  schema:
+                    type: string
+                - name: floatValueType
+                  in: query
+                  schema:
+                    type: number
+                    format: float
+                - name: doubleValueType
+                  in: query
+                  schema:
+                    type: number
+                    format: double
+                - name: timestampType
+                  in: query
+                  schema:
+                    type: string
+                    format: date-time
+                - name: durationType
+                  in: query
+                  schema:
+                    pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+                    type: string
+                    description: Represents a a duration between -315,576,000,000s and 315,576,000,000s (around 10000 years). Precision is in nanoseconds. 1 nanosecond is represented as 0.000000001s
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Message'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+        post:
+            operationId: Messaging_CreateMessage
+            parameters:
+                - name: messageId
+                  in: path
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/Message'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Message'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+        patch:
+            operationId: Messaging_UpdateMessage
+            parameters:
+                - name: messageId
+                  in: path
+                  required: true
+                  schema:
+                    type: string
+                - name: stringType
+                  in: query
+                  schema:
+                    type: string
+                - name: recursiveType.parentId
+                  in: query
+                  schema:
+                    type: integer
+                    format: int32
+                - name: recursiveType.child.childId
+                  in: query
+                  schema:
+                    type: integer
+                    format: int32
+                - name: recursiveType.child.parent.parentId
+                  in: query
+                  schema:
+                    type: integer
+                    format: int32
+                - name: recursiveType.child.parent.child.childId
+                  in: query
+                  schema:
+                    type: integer
+                    format: int32
+                - name: embeddedType.messageId
+                  in: query
+                  schema:
+                    type: string
+                - name: subType.messageId
+                  in: query
+                  schema:
+                    type: string
+                - name: subType.subSubMessage.messageId
+                  in: query
+                  schema:
+                    type: string
+                - name: subType.subSubMessage.integers
+                  in: query
+                  schema:
+                    type: array
+                    items:
+                        type: integer
+                        format: int32
+                - name: repeatedType
+                  in: query
+                  schema:
+                    type: array
+                    items:
+                        type: string
+                - name: valueType
+                  in: query
+                  description: Description of value
+                  schema:
+                    $ref: '#/components/schemas/GoogleProtobufValue'
+                - name: repeatedValueType
+                  in: query
+                  description: Description of repeated value
+                  schema:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/GoogleProtobufValue'
+                - name: boolValueType
+                  in: query
+                  schema:
+                    type: boolean
+                - name: bytesValueType
+                  in: query
+                  schema:
+                    type: string
+                    format: bytes
+                - name: int32ValueType
+                  in: query
+                  schema:
+                    type: integer
+                    format: int32
+                - name: uint32ValueType
+                  in: query
+                  schema:
+                    type: integer
+                    format: uint32
+                - name: stringValueType
+                  in: query
+                  schema:
+                    type: string
+                - name: int64ValueType
+                  in: query
+                  schema:
+                    type: string
+                - name: uint64ValueType
+                  in: query
+                  schema:
+                    type: string
+                - name: floatValueType
+                  in: query
+                  schema:
+                    type: number
+                    format: float
+                - name: doubleValueType
+                  in: query
+                  schema:
+                    type: number
+                    format: double
+                - name: timestampType
+                  in: query
+                  schema:
+                    type: string
+                    format: date-time
+                - name: durationType
+                  in: query
+                  schema:
+                    pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+                    type: string
+                    description: Represents a a duration between -315,576,000,000s and 315,576,000,000s (around 10000 years). Precision is in nanoseconds. 1 nanosecond is represented as 0.000000001s
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/messages:csv:
+        get:
+            description: |-
+                OpenAPI does not allow requestBody in GET operations.
+                 But it should not convert it to query params either.
+            operationId: Messaging_ListMessagesCSV
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        '*/*': {}
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+        post:
+            operationId: Messaging_CreateMessagesFromCSV
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            type: string
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        '*/*': {}
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+components:
+    schemas:
+        GoogleProtobufAny:
+            type: object
+            properties:
+                '@type':
+                    type: string
+                    description: The type of the serialized message.
+            additionalProperties: true
+            description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
+        GoogleProtobufValue:
+            description: Represents a dynamically typed value which can be either null, a number, a string, a boolean, a recursive struct value, or a list of values.
+        Message:
+            type: object
+            properties:
+                messageId:
+                    type: string
+                stringType:
+                    type: string
+                recursiveType:
+                    $ref: '#/components/schemas/RecursiveParent'
+                embeddedType:
+                    $ref: '#/components/schemas/Message_EmbMessage'
+                subType:
+                    $ref: '#/components/schemas/SubMessage'
+                repeatedType:
+                    type: array
+                    items:
+                        type: string
+                repeatedSubType:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/SubMessage'
+                repeatedRecursiveType:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/RecursiveParent'
+                mapType:
+                    type: object
+                    additionalProperties:
+                        type: string
+                body:
+                    type: object
+                media:
+                    type: array
+                    items:
+                        type: object
+                valueType:
+                    allOf:
+                        - $ref: '#/components/schemas/GoogleProtobufValue'
+                    description: Description of value
+                repeatedValueType:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/GoogleProtobufValue'
+                    description: Description of repeated value
+                boolValueType:
+                    type: boolean
+                bytesValueType:
+                    type: string
+                    format: bytes
+                int32ValueType:
+                    type: integer
+                    format: int32
+                uint32ValueType:
+                    type: integer
+                    format: uint32
+                stringValueType:
+                    type: string
+                int64ValueType:
+                    type: string
+                uint64ValueType:
+                    type: string
+                floatValueType:
+                    type: number
+                    format: float
+                doubleValueType:
+                    type: number
+                    format: double
+                timestampType:
+                    type: string
+                    format: date-time
+                durationType:
+                    pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+                    type: string
+        Message_EmbMessage:
+            type: object
+            properties:
+                messageId:
+                    type: string
+        RecursiveChild:
+            type: object
+            properties:
+                childId:
+                    type: integer
+                    format: int32
+                parent:
+                    $ref: '#/components/schemas/RecursiveParent'
+        RecursiveParent:
+            type: object
+            properties:
+                parentId:
+                    type: integer
+                    format: int32
+                child:
+                    $ref: '#/components/schemas/RecursiveChild'
+        Status:
+            type: object
+            properties:
+                code:
+                    type: integer
+                    description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
+                    format: int32
+                message:
+                    type: string
+                    description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
+                details:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/GoogleProtobufAny'
+                    description: A list of messages that carry the error details.  There is a common set of message types for APIs to use.
+            description: 'The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors).'
+        SubMessage:
+            type: object
+            properties:
+                messageId:
+                    type: string
+                subSubMessage:
+                    $ref: '#/components/schemas/SubSubMessage'
+        SubSubMessage:
+            type: object
+            properties:
+                messageId:
+                    type: string
+                integers:
+                    type: array
+                    items:
+                        type: integer
+                        format: int32

--- a/cmd/protoc-gen-openapi/examples/tests/rpctypes/openapi_disable_service_tags.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/rpctypes/openapi_disable_service_tags.yaml
@@ -1,0 +1,50 @@
+# Generated with protoc-gen-openapi
+# https://github.com/google/gnostic/tree/master/cmd/protoc-gen-openapi
+
+openapi: 3.0.3
+info:
+    title: ""
+    version: 0.0.1
+paths:
+    /v1/status:
+        get:
+            operationId: Status_GetStatus
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+components:
+    schemas:
+        GoogleProtobufAny:
+            type: object
+            properties:
+                '@type':
+                    type: string
+                    description: The type of the serialized message.
+            additionalProperties: true
+            description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
+        Status:
+            type: object
+            properties:
+                code:
+                    type: integer
+                    description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
+                    format: int32
+                message:
+                    type: string
+                    description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
+                details:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/GoogleProtobufAny'
+                    description: A list of messages that carry the error details.  There is a common set of message types for APIs to use.
+            description: 'The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors).'

--- a/cmd/protoc-gen-openapi/examples/tests/servicetags/message.proto
+++ b/cmd/protoc-gen-openapi/examples/tests/servicetags/message.proto
@@ -1,0 +1,40 @@
+// Copyright 2024 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+package tests.servicetags.message.v1;
+
+import "google/api/annotations.proto";
+import "openapiv3/annotations.proto";
+
+option go_package = "github.com/google/gnostic/apps/protoc-gen-openapi/examples/tests/servicetags/message/v1;message";
+
+service Messaging1 {
+  rpc UpdateMessage(Message) returns(Message) {
+    option (google.api.http) = {
+        patch: "/v1/messages/{message_id}"
+        body: "*"
+    };
+    option (openapi.v3.operation) = {
+      tags: "Messaging Operation"
+    };
+  }
+}
+
+message Message {
+  int64 id = 1;
+  string label = 2;
+}

--- a/cmd/protoc-gen-openapi/examples/tests/servicetags/openapi.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/servicetags/openapi.yaml
@@ -1,0 +1,74 @@
+# Generated with protoc-gen-openapi
+# https://github.com/google/gnostic/tree/master/cmd/protoc-gen-openapi
+
+openapi: 3.0.3
+info:
+    title: Messaging1 API
+    version: 0.0.1
+paths:
+    /v1/messages/{message_id}:
+        patch:
+            tags:
+                - Messaging1
+                - Messaging Operation
+            operationId: Messaging1_UpdateMessage
+            parameters:
+                - name: message_id
+                  in: path
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/Message'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Message'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+components:
+    schemas:
+        GoogleProtobufAny:
+            type: object
+            properties:
+                '@type':
+                    type: string
+                    description: The type of the serialized message.
+            additionalProperties: true
+            description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
+        Message:
+            type: object
+            properties:
+                id:
+                    type: string
+                label:
+                    type: string
+        Status:
+            type: object
+            properties:
+                code:
+                    type: integer
+                    description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
+                    format: int32
+                message:
+                    type: string
+                    description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
+                details:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/GoogleProtobufAny'
+                    description: A list of messages that carry the error details.  There is a common set of message types for APIs to use.
+            description: 'The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors).'
+tags:
+    - name: Messaging1

--- a/cmd/protoc-gen-openapi/examples/tests/servicetags/openapi_default_response.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/servicetags/openapi_default_response.yaml
@@ -1,0 +1,74 @@
+# Generated with protoc-gen-openapi
+# https://github.com/google/gnostic/tree/master/cmd/protoc-gen-openapi
+
+openapi: 3.0.3
+info:
+    title: Messaging1 API
+    version: 0.0.1
+paths:
+    /v1/messages/{message_id}:
+        patch:
+            tags:
+                - Messaging1
+                - Messaging Operation
+            operationId: Messaging1_UpdateMessage
+            parameters:
+                - name: message_id
+                  in: path
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/Message'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Message'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+components:
+    schemas:
+        GoogleProtobufAny:
+            type: object
+            properties:
+                '@type':
+                    type: string
+                    description: The type of the serialized message.
+            additionalProperties: true
+            description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
+        Message:
+            type: object
+            properties:
+                id:
+                    type: string
+                label:
+                    type: string
+        Status:
+            type: object
+            properties:
+                code:
+                    type: integer
+                    description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
+                    format: int32
+                message:
+                    type: string
+                    description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
+                details:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/GoogleProtobufAny'
+                    description: A list of messages that carry the error details.  There is a common set of message types for APIs to use.
+            description: 'The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors).'
+tags:
+    - name: Messaging1

--- a/cmd/protoc-gen-openapi/examples/tests/servicetags/openapi_disable_service_tags.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/servicetags/openapi_disable_service_tags.yaml
@@ -1,0 +1,71 @@
+# Generated with protoc-gen-openapi
+# https://github.com/google/gnostic/tree/master/cmd/protoc-gen-openapi
+
+openapi: 3.0.3
+info:
+    title: ""
+    version: 0.0.1
+paths:
+    /v1/messages/{message_id}:
+        patch:
+            tags:
+                - Messaging Operation
+            operationId: Messaging1_UpdateMessage
+            parameters:
+                - name: message_id
+                  in: path
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/Message'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Message'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+components:
+    schemas:
+        GoogleProtobufAny:
+            type: object
+            properties:
+                '@type':
+                    type: string
+                    description: The type of the serialized message.
+            additionalProperties: true
+            description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
+        Message:
+            type: object
+            properties:
+                id:
+                    type: string
+                label:
+                    type: string
+        Status:
+            type: object
+            properties:
+                code:
+                    type: integer
+                    description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
+                    format: int32
+                message:
+                    type: string
+                    description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
+                details:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/GoogleProtobufAny'
+                    description: A list of messages that carry the error details.  There is a common set of message types for APIs to use.
+            description: 'The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors).'

--- a/cmd/protoc-gen-openapi/examples/tests/servicetags/openapi_fq_schema_naming.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/servicetags/openapi_fq_schema_naming.yaml
@@ -1,0 +1,74 @@
+# Generated with protoc-gen-openapi
+# https://github.com/google/gnostic/tree/master/cmd/protoc-gen-openapi
+
+openapi: 3.0.3
+info:
+    title: Messaging1 API
+    version: 0.0.1
+paths:
+    /v1/messages/{message_id}:
+        patch:
+            tags:
+                - Messaging1
+                - Messaging Operation
+            operationId: Messaging1_UpdateMessage
+            parameters:
+                - name: message_id
+                  in: path
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/tests.servicetags.message.v1.Message'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/tests.servicetags.message.v1.Message'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/google.rpc.Status'
+components:
+    schemas:
+        google.protobuf.Any:
+            type: object
+            properties:
+                '@type':
+                    type: string
+                    description: The type of the serialized message.
+            additionalProperties: true
+            description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
+        google.rpc.Status:
+            type: object
+            properties:
+                code:
+                    type: integer
+                    description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
+                    format: int32
+                message:
+                    type: string
+                    description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
+                details:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/google.protobuf.Any'
+                    description: A list of messages that carry the error details.  There is a common set of message types for APIs to use.
+            description: 'The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors).'
+        tests.servicetags.message.v1.Message:
+            type: object
+            properties:
+                id:
+                    type: string
+                label:
+                    type: string
+tags:
+    - name: Messaging1

--- a/cmd/protoc-gen-openapi/examples/tests/servicetags/openapi_json.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/servicetags/openapi_json.yaml
@@ -1,0 +1,74 @@
+# Generated with protoc-gen-openapi
+# https://github.com/google/gnostic/tree/master/cmd/protoc-gen-openapi
+
+openapi: 3.0.3
+info:
+    title: Messaging1 API
+    version: 1.2.3
+paths:
+    /v1/messages/{message_id}:
+        patch:
+            tags:
+                - Messaging1
+                - Messaging Operation
+            operationId: Messaging1_UpdateMessage
+            parameters:
+                - name: message_id
+                  in: path
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/Message'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Message'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+components:
+    schemas:
+        GoogleProtobufAny:
+            type: object
+            properties:
+                '@type':
+                    type: string
+                    description: The type of the serialized message.
+            additionalProperties: true
+            description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
+        Message:
+            type: object
+            properties:
+                id:
+                    type: string
+                label:
+                    type: string
+        Status:
+            type: object
+            properties:
+                code:
+                    type: integer
+                    description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
+                    format: int32
+                message:
+                    type: string
+                    description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
+                details:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/GoogleProtobufAny'
+                    description: A list of messages that carry the error details.  There is a common set of message types for APIs to use.
+            description: 'The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors).'
+tags:
+    - name: Messaging1

--- a/cmd/protoc-gen-openapi/examples/tests/servicetags/openapi_string_enum.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/servicetags/openapi_string_enum.yaml
@@ -1,0 +1,74 @@
+# Generated with protoc-gen-openapi
+# https://github.com/google/gnostic/tree/master/cmd/protoc-gen-openapi
+
+openapi: 3.0.3
+info:
+    title: Messaging1 API
+    version: 0.0.1
+paths:
+    /v1/messages/{message_id}:
+        patch:
+            tags:
+                - Messaging1
+                - Messaging Operation
+            operationId: Messaging1_UpdateMessage
+            parameters:
+                - name: message_id
+                  in: path
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/Message'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Message'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+components:
+    schemas:
+        GoogleProtobufAny:
+            type: object
+            properties:
+                '@type':
+                    type: string
+                    description: The type of the serialized message.
+            additionalProperties: true
+            description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
+        Message:
+            type: object
+            properties:
+                id:
+                    type: string
+                label:
+                    type: string
+        Status:
+            type: object
+            properties:
+                code:
+                    type: integer
+                    description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
+                    format: int32
+                message:
+                    type: string
+                    description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
+                details:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/GoogleProtobufAny'
+                    description: A list of messages that carry the error details.  There is a common set of message types for APIs to use.
+            description: 'The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors).'
+tags:
+    - name: Messaging1

--- a/cmd/protoc-gen-openapi/main.go
+++ b/cmd/protoc-gen-openapi/main.go
@@ -29,15 +29,16 @@ var flags flag.FlagSet
 
 func main() {
 	conf := generator.Configuration{
-		Version:         flags.String("version", "0.0.1", "version number text, e.g. 1.2.3"),
-		Title:           flags.String("title", "", "name of the API"),
-		Description:     flags.String("description", "", "description of the API"),
-		Naming:          flags.String("naming", "json", `naming convention. Use "proto" for passing names directly from the proto files`),
-		FQSchemaNaming:  flags.Bool("fq_schema_naming", false, `schema naming convention. If "true", generates fully-qualified schema names by prefixing them with the proto message package name`),
-		EnumType:        flags.String("enum_type", "integer", `type for enum serialization. Use "string" for string-based serialization`),
-		CircularDepth:   flags.Int("depth", 2, "depth of recursion for circular messages"),
-		DefaultResponse: flags.Bool("default_response", true, `add default response. If "true", automatically adds a default response to operations which use the google.rpc.Status message. Useful if you use envoy or grpc-gateway to transcode as they use this type for their default error responses.`),
-		OutputMode:      flags.String("output_mode", "merged", `output generation mode. By default, a single openapi.yaml is generated at the out folder. Use "source_relative' to generate a separate '[inputfile].openapi.yaml' next to each '[inputfile].proto'.`),
+		Version:            flags.String("version", "0.0.1", "version number text, e.g. 1.2.3"),
+		Title:              flags.String("title", "", "name of the API"),
+		Description:        flags.String("description", "", "description of the API"),
+		Naming:             flags.String("naming", "json", `naming convention. Use "proto" for passing names directly from the proto files`),
+		FQSchemaNaming:     flags.Bool("fq_schema_naming", false, `schema naming convention. If "true", generates fully-qualified schema names by prefixing them with the proto message package name`),
+		DisableServiceTags: flags.Bool("disable_service_tags", false, `if "true", a tag for the name of the service is not added to each operation`),
+		EnumType:           flags.String("enum_type", "integer", `type for enum serialization. Use "string" for string-based serialization`),
+		CircularDepth:      flags.Int("depth", 2, "depth of recursion for circular messages"),
+		DefaultResponse:    flags.Bool("default_response", true, `add default response. If "true", automatically adds a default response to operations which use the google.rpc.Status message. Useful if you use envoy or grpc-gateway to transcode as they use this type for their default error responses.`),
+		OutputMode:         flags.String("output_mode", "merged", `output generation mode. By default, a single openapi.yaml is generated at the out folder. Use "source_relative' to generate a separate '[inputfile].openapi.yaml' next to each '[inputfile].proto'.`),
 	}
 
 	opts := protogen.Options{

--- a/cmd/protoc-gen-openapi/plugin_test.go
+++ b/cmd/protoc-gen-openapi/plugin_test.go
@@ -43,6 +43,7 @@ var openapiTests = []struct {
 	{name: "OpenAPIv3 Annotations", path: "examples/tests/openapiv3annotations/", protofile: "message.proto"},
 	{name: "AllOf Wrap Message", path: "examples/tests/allofwrap/", protofile: "message.proto"},
 	{name: "Additional Bindings", path: "examples/tests/additional_bindings/", protofile: "message.proto"},
+	{name: "Service Tags", path: "examples/tests/servicetags/", protofile: "message.proto"},
 }
 
 // Set this to true to generate/overwrite the fixtures. Make sure you set it back
@@ -271,6 +272,43 @@ func TestOpenAPIDefaultResponse(t *testing.T) {
 				"-I", "examples",
 				path.Join(tt.path, tt.protofile),
 				"--openapi_out=default_response=true:.").Run()
+			if err != nil {
+				t.Fatalf("protoc failed: %+v", err)
+			}
+			if GENERATE_FIXTURES {
+				err := CopyFixture(TEMP_FILE, fixture)
+				if err != nil {
+					t.Fatalf("Can't generate fixture: %+v", err)
+				}
+			} else {
+				// Verify that the generated spec matches our expected version.
+				err = exec.Command("diff", TEMP_FILE, fixture).Run()
+				if err != nil {
+					t.Fatalf("diff failed: %+v", err)
+				}
+			}
+			// if the test succeeded, clean up
+			os.Remove(TEMP_FILE)
+		})
+	}
+}
+
+func TestOpenAPIServiceTags(t *testing.T) {
+	for _, tt := range openapiTests {
+		fixture := path.Join(tt.path, "openapi_disable_service_tags.yaml")
+		if _, err := os.Stat(fixture); errors.Is(err, os.ErrNotExist) {
+			if !GENERATE_FIXTURES {
+				continue
+			}
+		}
+		t.Run(tt.name, func(t *testing.T) {
+			// Run protoc and the protoc-gen-openapi plugin to generate an OpenAPI spec with string Enums.
+			err := exec.Command("protoc",
+				"-I", "../../",
+				"-I", "../../third_party",
+				"-I", "examples",
+				path.Join(tt.path, tt.protofile),
+				"--openapi_out=disable_service_tags=true:.").Run()
 			if err != nil {
 				t.Fatalf("protoc failed: %+v", err)
 			}


### PR DESCRIPTION
This addresses issue #363 so that a tag is not added to each operation with the name of the service given the right command line option. This option is available in `protoc-gen-openapiv2` and makes the transition to gnostic a little easier.