### PR TITLE
Revert "[+] support integer64 as string option (#355)"

### DIFF
--- a/cmd/protoc-gen-openapi/examples/tests/mapfields/openapi.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/mapfields/openapi.yaml
@@ -42,7 +42,8 @@ components:
             type: object
             properties:
                 id:
-                    type: string
+                    type: integer
+                    format: int64
                 label:
                     type: string
         GoogleProtobufAny:
@@ -90,7 +91,8 @@ components:
             type: object
             properties:
                 id:
-                    type: string
+                    type: integer
+                    format: int64
                 label:
                     type: string
         Status:

--- a/cmd/protoc-gen-openapi/examples/tests/mapfields/openapi_default_response.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/mapfields/openapi_default_response.yaml
@@ -42,7 +42,8 @@ components:
             type: object
             properties:
                 id:
-                    type: string
+                    type: integer
+                    format: int64
                 label:
                     type: string
         GoogleProtobufAny:
@@ -90,7 +91,8 @@ components:
             type: object
             properties:
                 id:
-                    type: string
+                    type: integer
+                    format: int64
                 label:
                     type: string
         Status:

--- a/cmd/protoc-gen-openapi/examples/tests/mapfields/openapi_fq_schema_naming.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/mapfields/openapi_fq_schema_naming.yaml
@@ -66,7 +66,8 @@ components:
             type: object
             properties:
                 id:
-                    type: string
+                    type: integer
+                    format: int64
                 label:
                     type: string
         tests.mapfields.message.v1.Message:
@@ -106,7 +107,8 @@ components:
             type: object
             properties:
                 id:
-                    type: string
+                    type: integer
+                    format: int64
                 label:
                     type: string
 tags:

--- a/cmd/protoc-gen-openapi/examples/tests/mapfields/openapi_json.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/mapfields/openapi_json.yaml
@@ -42,7 +42,8 @@ components:
             type: object
             properties:
                 id:
-                    type: string
+                    type: integer
+                    format: int64
                 label:
                     type: string
         GoogleProtobufAny:
@@ -90,7 +91,8 @@ components:
             type: object
             properties:
                 id:
-                    type: string
+                    type: integer
+                    format: int64
                 label:
                     type: string
         Status:

--- a/cmd/protoc-gen-openapi/examples/tests/mapfields/openapi_string_enum.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/mapfields/openapi_string_enum.yaml
@@ -42,7 +42,8 @@ components:
             type: object
             properties:
                 id:
-                    type: string
+                    type: integer
+                    format: int64
                 label:
                     type: string
         GoogleProtobufAny:
@@ -90,7 +91,8 @@ components:
             type: object
             properties:
                 id:
-                    type: string
+                    type: integer
+                    format: int64
                 label:
                     type: string
         Status:

--- a/cmd/protoc-gen-openapi/examples/tests/noannotations/openapi.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/noannotations/openapi.yaml
@@ -50,7 +50,8 @@ components:
             type: object
             properties:
                 id:
-                    type: string
+                    type: integer
+                    format: int64
                 label:
                     type: string
         Status:

--- a/cmd/protoc-gen-openapi/examples/tests/noannotations/openapi_default_response.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/noannotations/openapi_default_response.yaml
@@ -50,7 +50,8 @@ components:
             type: object
             properties:
                 id:
-                    type: string
+                    type: integer
+                    format: int64
                 label:
                     type: string
         Status:

--- a/cmd/protoc-gen-openapi/examples/tests/noannotations/openapi_fq_schema_naming.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/noannotations/openapi_fq_schema_naming.yaml
@@ -66,7 +66,8 @@ components:
             type: object
             properties:
                 id:
-                    type: string
+                    type: integer
+                    format: int64
                 label:
                     type: string
 tags:

--- a/cmd/protoc-gen-openapi/examples/tests/noannotations/openapi_json.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/noannotations/openapi_json.yaml
@@ -50,7 +50,8 @@ components:
             type: object
             properties:
                 id:
-                    type: string
+                    type: integer
+                    format: int64
                 label:
                     type: string
         Status:

--- a/cmd/protoc-gen-openapi/examples/tests/noannotations/openapi_string_enum.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/noannotations/openapi_string_enum.yaml
@@ -50,7 +50,8 @@ components:
             type: object
             properties:
                 id:
-                    type: string
+                    type: integer
+                    format: int64
                 label:
                     type: string
         Status:

--- a/cmd/protoc-gen-openapi/examples/tests/openapiv3annotations/openapi.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/openapiv3annotations/openapi.yaml
@@ -61,7 +61,8 @@ components:
             type: object
             properties:
                 id:
-                    type: string
+                    type: integer
+                    format: int64
                 label:
                     title: this is an overriden field schema title
                     maxLength: 255

--- a/cmd/protoc-gen-openapi/examples/tests/openapiv3annotations/openapi_default_response.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/openapiv3annotations/openapi_default_response.yaml
@@ -61,7 +61,8 @@ components:
             type: object
             properties:
                 id:
-                    type: string
+                    type: integer
+                    format: int64
                 label:
                     title: this is an overriden field schema title
                     maxLength: 255

--- a/cmd/protoc-gen-openapi/examples/tests/openapiv3annotations/openapi_fq_schema_naming.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/openapiv3annotations/openapi_fq_schema_naming.yaml
@@ -77,7 +77,8 @@ components:
             type: object
             properties:
                 id:
-                    type: string
+                    type: integer
+                    format: int64
                 label:
                     title: this is an overriden field schema title
                     maxLength: 255

--- a/cmd/protoc-gen-openapi/examples/tests/openapiv3annotations/openapi_json.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/openapiv3annotations/openapi_json.yaml
@@ -61,7 +61,8 @@ components:
             type: object
             properties:
                 id:
-                    type: string
+                    type: integer
+                    format: int64
                 label:
                     title: this is an overriden field schema title
                     maxLength: 255

--- a/cmd/protoc-gen-openapi/examples/tests/openapiv3annotations/openapi_string_enum.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/openapiv3annotations/openapi_string_enum.yaml
@@ -61,7 +61,8 @@ components:
             type: object
             properties:
                 id:
-                    type: string
+                    type: integer
+                    format: int64
                 label:
                     title: this is an overriden field schema title
                     maxLength: 255

--- a/cmd/protoc-gen-openapi/examples/tests/pathparams/openapi.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/pathparams/openapi.yaml
@@ -20,7 +20,8 @@ paths:
                 - name: user_id
                   in: query
                   schema:
-                    type: string
+                    type: integer
+                    format: uint64
             responses:
                 "200":
                     description: OK
@@ -73,7 +74,8 @@ paths:
                   in: path
                   required: true
                   schema:
-                    type: string
+                    type: integer
+                    format: uint64
                 - name: message_id
                   in: path
                   required: true
@@ -108,7 +110,8 @@ components:
                 message_id:
                     type: string
                 user_id:
-                    type: string
+                    type: integer
+                    format: uint64
                 content:
                     type: string
                 maybe:

--- a/cmd/protoc-gen-openapi/examples/tests/pathparams/openapi_default_response.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/pathparams/openapi_default_response.yaml
@@ -20,7 +20,8 @@ paths:
                 - name: userId
                   in: query
                   schema:
-                    type: string
+                    type: integer
+                    format: uint64
             responses:
                 "200":
                     description: OK
@@ -73,7 +74,8 @@ paths:
                   in: path
                   required: true
                   schema:
-                    type: string
+                    type: integer
+                    format: uint64
                 - name: messageId
                   in: path
                   required: true
@@ -108,7 +110,8 @@ components:
                 messageId:
                     type: string
                 userId:
-                    type: string
+                    type: integer
+                    format: uint64
                 content:
                     type: string
                 maybe:

--- a/cmd/protoc-gen-openapi/examples/tests/pathparams/openapi_fq_schema_naming.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/pathparams/openapi_fq_schema_naming.yaml
@@ -20,7 +20,8 @@ paths:
                 - name: userId
                   in: query
                   schema:
-                    type: string
+                    type: integer
+                    format: uint64
             responses:
                 "200":
                     description: OK
@@ -73,7 +74,8 @@ paths:
                   in: path
                   required: true
                   schema:
-                    type: string
+                    type: integer
+                    format: uint64
                 - name: messageId
                   in: path
                   required: true
@@ -124,7 +126,8 @@ components:
                 messageId:
                     type: string
                 userId:
-                    type: string
+                    type: integer
+                    format: uint64
                 content:
                     type: string
                 maybe:

--- a/cmd/protoc-gen-openapi/examples/tests/pathparams/openapi_json.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/pathparams/openapi_json.yaml
@@ -20,7 +20,8 @@ paths:
                 - name: userId
                   in: query
                   schema:
-                    type: string
+                    type: integer
+                    format: uint64
             responses:
                 "200":
                     description: OK
@@ -73,7 +74,8 @@ paths:
                   in: path
                   required: true
                   schema:
-                    type: string
+                    type: integer
+                    format: uint64
                 - name: messageId
                   in: path
                   required: true
@@ -108,7 +110,8 @@ components:
                 messageId:
                     type: string
                 userId:
-                    type: string
+                    type: integer
+                    format: uint64
                 content:
                     type: string
                 maybe:

--- a/cmd/protoc-gen-openapi/examples/tests/pathparams/openapi_string_enum.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/pathparams/openapi_string_enum.yaml
@@ -20,7 +20,8 @@ paths:
                 - name: userId
                   in: query
                   schema:
-                    type: string
+                    type: integer
+                    format: uint64
             responses:
                 "200":
                     description: OK
@@ -73,7 +74,8 @@ paths:
                   in: path
                   required: true
                   schema:
-                    type: string
+                    type: integer
+                    format: uint64
                 - name: messageId
                   in: path
                   required: true
@@ -108,7 +110,8 @@ components:
                 messageId:
                     type: string
                 userId:
-                    type: string
+                    type: integer
+                    format: uint64
                 content:
                     type: string
                 maybe:

--- a/cmd/protoc-gen-openapi/generator/reflector.go
+++ b/cmd/protoc-gen-openapi/generator/reflector.go
@@ -208,12 +208,10 @@ func (r *OpenAPIv3Reflector) schemaOrReferenceForField(field protoreflect.FieldD
 		kindSchema = wk.NewStringSchema()
 
 	case protoreflect.Int32Kind, protoreflect.Sint32Kind, protoreflect.Uint32Kind,
-		protoreflect.Sfixed32Kind, protoreflect.Fixed32Kind:
+		protoreflect.Int64Kind, protoreflect.Sint64Kind, protoreflect.Uint64Kind,
+		protoreflect.Sfixed32Kind, protoreflect.Fixed32Kind, protoreflect.Sfixed64Kind,
+		protoreflect.Fixed64Kind:
 		kindSchema = wk.NewIntegerSchema(kind.String())
-
-	case protoreflect.Int64Kind, protoreflect.Sint64Kind, protoreflect.Uint64Kind,
-		protoreflect.Sfixed64Kind, protoreflect.Fixed64Kind:
-		kindSchema = wk.NewStringSchema()
 
 	case protoreflect.EnumKind:
 		kindSchema = wk.NewEnumSchema(*&r.conf.EnumType, field)


### PR DESCRIPTION
ref: https://github.com/google/gnostic/pull/355
closes: https://github.com/google/gnostic/issues/411

This reverts commit c62333b7964941ab26259ef3648690e6bdd34459.

The original change conflated generating an OpenAPI v3 spec file with the guidance for encoding protobuf messages as json objects. OpenAPI v3 explicitly allows for integer types of int64 (https://swagger.io/docs/specification/data-models/data-types/#numbers). The OpenAPI v3 spec generated by this tool will then usually be fed into language specific generators which will determine how they want to handle each of the types depending on the specific target language.