### PR TITLE
fix: fetch field property option for path variable and query (#436)

### DIFF
--- a/cmd/protoc-gen-openapi/examples/tests/openapiv3annotations/message.proto
+++ b/cmd/protoc-gen-openapi/examples/tests/openapiv3annotations/message.proto
@@ -75,6 +75,13 @@ service Messaging1 {
         ]
     };
   }
+  // while field in message has overriden field, it should reflect in "parameters" section
+  rpc GetMessageById(Message2) returns(Message2) {
+    option(google.api.http) = {
+        // id should have limit since id in message2 have the limit
+        get: "/v1/messages2/{id}"
+    };
+  }
 }
 
 service Messaging2 {
@@ -88,6 +95,19 @@ message Message {
 
   int64 id = 1;
   string label = 2 [
+    (openapi.v3.property) = {
+      title: "this is an overriden field schema title";
+      max_length: 255;
+    }
+  ];
+}
+
+message Message2 {
+  option (openapi.v3.schema) = {
+    title: "This is an overridden message schema title";
+  };
+
+  string id = 1 [
     (openapi.v3.property) = {
       title: "this is an overriden field schema title";
       max_length: 255;

--- a/cmd/protoc-gen-openapi/examples/tests/openapiv3annotations/openapi.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/openapiv3annotations/openapi.yaml
@@ -46,6 +46,33 @@ paths:
                                 $ref: '#/components/schemas/Status'
             security:
                 - BasicAuth: []
+    /v1/messages2/{id}:
+        get:
+            tags:
+                - Messaging1
+            description: while field in message has overriden field, it should reflect in "parameters" section
+            operationId: Messaging1_GetMessageById
+            parameters:
+                - name: id
+                  in: path
+                  required: true
+                  schema:
+                    title: this is an overriden field schema title
+                    maxLength: 255
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Message2'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
 components:
     schemas:
         GoogleProtobufAny:
@@ -63,6 +90,14 @@ components:
                 id:
                     type: string
                 label:
+                    title: this is an overriden field schema title
+                    maxLength: 255
+                    type: string
+        Message2:
+            title: This is an overridden message schema title
+            type: object
+            properties:
+                id:
                     title: this is an overriden field schema title
                     maxLength: 255
                     type: string

--- a/cmd/protoc-gen-openapi/examples/tests/openapiv3annotations/openapi_default_response.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/openapiv3annotations/openapi_default_response.yaml
@@ -46,6 +46,33 @@ paths:
                                 $ref: '#/components/schemas/Status'
             security:
                 - BasicAuth: []
+    /v1/messages2/{id}:
+        get:
+            tags:
+                - Messaging1
+            description: while field in message has overriden field, it should reflect in "parameters" section
+            operationId: Messaging1_GetMessageById
+            parameters:
+                - name: id
+                  in: path
+                  required: true
+                  schema:
+                    title: this is an overriden field schema title
+                    maxLength: 255
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Message2'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
 components:
     schemas:
         GoogleProtobufAny:
@@ -63,6 +90,14 @@ components:
                 id:
                     type: string
                 label:
+                    title: this is an overriden field schema title
+                    maxLength: 255
+                    type: string
+        Message2:
+            title: This is an overridden message schema title
+            type: object
+            properties:
+                id:
                     title: this is an overriden field schema title
                     maxLength: 255
                     type: string

--- a/cmd/protoc-gen-openapi/examples/tests/openapiv3annotations/openapi_fq_schema_naming.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/openapiv3annotations/openapi_fq_schema_naming.yaml
@@ -46,6 +46,33 @@ paths:
                                 $ref: '#/components/schemas/google.rpc.Status'
             security:
                 - BasicAuth: []
+    /v1/messages2/{id}:
+        get:
+            tags:
+                - Messaging1
+            description: while field in message has overriden field, it should reflect in "parameters" section
+            operationId: Messaging1_GetMessageById
+            parameters:
+                - name: id
+                  in: path
+                  required: true
+                  schema:
+                    title: this is an overriden field schema title
+                    maxLength: 255
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/tests.openapiv3annotations.message.v1.Message2'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/google.rpc.Status'
 components:
     schemas:
         google.protobuf.Any:
@@ -79,6 +106,14 @@ components:
                 id:
                     type: string
                 label:
+                    title: this is an overriden field schema title
+                    maxLength: 255
+                    type: string
+        tests.openapiv3annotations.message.v1.Message2:
+            title: This is an overridden message schema title
+            type: object
+            properties:
+                id:
                     title: this is an overriden field schema title
                     maxLength: 255
                     type: string

--- a/cmd/protoc-gen-openapi/examples/tests/openapiv3annotations/openapi_json.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/openapiv3annotations/openapi_json.yaml
@@ -46,6 +46,33 @@ paths:
                                 $ref: '#/components/schemas/Status'
             security:
                 - BasicAuth: []
+    /v1/messages2/{id}:
+        get:
+            tags:
+                - Messaging1
+            description: while field in message has overriden field, it should reflect in "parameters" section
+            operationId: Messaging1_GetMessageById
+            parameters:
+                - name: id
+                  in: path
+                  required: true
+                  schema:
+                    title: this is an overriden field schema title
+                    maxLength: 255
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Message2'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
 components:
     schemas:
         GoogleProtobufAny:
@@ -63,6 +90,14 @@ components:
                 id:
                     type: string
                 label:
+                    title: this is an overriden field schema title
+                    maxLength: 255
+                    type: string
+        Message2:
+            title: This is an overridden message schema title
+            type: object
+            properties:
+                id:
                     title: this is an overriden field schema title
                     maxLength: 255
                     type: string

--- a/cmd/protoc-gen-openapi/examples/tests/openapiv3annotations/openapi_string_enum.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/openapiv3annotations/openapi_string_enum.yaml
@@ -46,6 +46,33 @@ paths:
                                 $ref: '#/components/schemas/Status'
             security:
                 - BasicAuth: []
+    /v1/messages2/{id}:
+        get:
+            tags:
+                - Messaging1
+            description: while field in message has overriden field, it should reflect in "parameters" section
+            operationId: Messaging1_GetMessageById
+            parameters:
+                - name: id
+                  in: path
+                  required: true
+                  schema:
+                    title: this is an overriden field schema title
+                    maxLength: 255
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Message2'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
 components:
     schemas:
         GoogleProtobufAny:
@@ -63,6 +90,14 @@ components:
                 id:
                     type: string
                 label:
+                    title: this is an overriden field schema title
+                    maxLength: 255
+                    type: string
+        Message2:
+            title: This is an overridden message schema title
+            type: object
+            properties:
+                id:
                     title: this is an overriden field schema title
                     maxLength: 255
                     type: string


### PR DESCRIPTION
fix: fetch field property option for path variable and query (#436)

while path variable and query in message body, the `parameters` in generated yaml should contain the overridden properties.

Updated tests for openapiv3 as well