### PR TITLE
chore: Update README.md to fix installation instructions

### DIFF
--- a/cmd/protoc-gen-openapi/README.md
+++ b/cmd/protoc-gen-openapi/README.md
@@ -6,7 +6,7 @@ Protocol Buffer service.
 
 Installation:
 
-    go install github.com/google/gnostic/cmd/protoc-gen-openapi
+    go install github.com/google/gnostic/cmd/protoc-gen-openapi@latest
 
 Usage:
 


### PR DESCRIPTION
Fix this error in the installation instructions:

```
go install github.com/google/gnostic/cmd/protoc-gen-openapi
go: 'go install' requires a version when current directory is not in a module
	Try 'go install github.com/google/gnostic/cmd/protoc-gen-openapi@latest' to install the latest version
```