### PR TITLE
feat: add summary field to operations from first non-empty comment line

### DIFF
--- a/cmd/protoc-gen-openapi/generator/generator.go
+++ b/cmd/protoc-gen-openapi/generator/generator.go
@@ -600,6 +600,7 @@ func (g *OpenAPIv3Generator) buildOperationV3(
 	// Create the operation.
 	op := &v3.Operation{
 		Tags:        []string{tagName},
+		Summary:     extractSummary(description),
 		Description: description,
 		OperationId: operationID,
 		Parameters:  parameters,
@@ -666,6 +667,17 @@ func (g *OpenAPIv3Generator) buildOperationV3(
 		}
 	}
 	return op, path
+}
+
+func extractSummary(comment string) string {
+	lines := strings.Split(comment, "\n")
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
 }
 
 // addOperationToDocumentV3 adds an operation to the specified path/method.


### PR DESCRIPTION
- Extract and add the first non-empty line of the comment as the summary
- Improve operation description by providing a concise summary