### PR TITLE
Generate int64 types as integer instead of string in OpenAPI schema

### DIFF
--- a/cmd/protoc-gen-openapi/examples/tests/additional_bindings/openapi_default_response.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/additional_bindings/openapi_default_response.yaml
@@ -6,39 +6,35 @@ info:
     title: Messaging API
     version: 0.0.1
 paths:
-    /v1/messages/{messageId}:
-        get:
+    /v1/messages:
+        patch:
             tags:
                 - Messaging
-            operationId: Messaging_GetMessage
-            parameters:
-                - name: messageId
-                  in: path
-                  required: true
-                  schema:
-                    type: string
-                - name: userId
-                  in: query
-                  schema:
-                    type: integer
-                    format: uint64
+            operationId: Messaging_UpdateMessage
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/Message'
+                required: true
             responses:
                 "200":
                     description: OK
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/tests.pathparams.message.v1.Message'
+                                $ref: '#/components/schemas/Message'
                 default:
                     description: Default error response
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/google.rpc.Status'
-        post:
+                                $ref: '#/components/schemas/Status'
+    /v1/messages/{messageId}:
+        patch:
             tags:
                 - Messaging
-            operationId: Messaging_CreateMessage
+            operationId: Messaging_UpdateMessage
             parameters:
                 - name: messageId
                   in: path
@@ -49,7 +45,7 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/tests.pathparams.message.v1.Message'
+                            type: string
                 required: true
             responses:
                 "200":
@@ -57,46 +53,16 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/tests.pathparams.message.v1.Message'
+                                $ref: '#/components/schemas/Message'
                 default:
                     description: Default error response
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/google.rpc.Status'
-    /v1/users/{userId}/messages/{messageId}:
-        get:
-            tags:
-                - Messaging
-            operationId: Messaging_GetUserMessage
-            parameters:
-                - name: userId
-                  in: path
-                  required: true
-                  schema:
-                    type: integer
-                    format: uint64
-                - name: messageId
-                  in: path
-                  required: true
-                  schema:
-                    type: string
-            responses:
-                "200":
-                    description: OK
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/tests.pathparams.message.v1.Message'
-                default:
-                    description: Default error response
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/google.rpc.Status'
+                                $ref: '#/components/schemas/Status'
 components:
     schemas:
-        google.protobuf.Any:
+        GoogleProtobufAny:
             type: object
             properties:
                 '@type':
@@ -104,7 +70,14 @@ components:
                     description: The type of the serialized message.
             additionalProperties: true
             description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
-        google.rpc.Status:
+        Message:
+            type: object
+            properties:
+                messageId:
+                    type: string
+                text:
+                    type: string
+        Status:
             type: object
             properties:
                 code:
@@ -117,20 +90,8 @@ components:
                 details:
                     type: array
                     items:
-                        $ref: '#/components/schemas/google.protobuf.Any'
+                        $ref: '#/components/schemas/GoogleProtobufAny'
                     description: A list of messages that carry the error details.  There is a common set of message types for APIs to use.
             description: 'The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors).'
-        tests.pathparams.message.v1.Message:
-            type: object
-            properties:
-                messageId:
-                    type: string
-                userId:
-                    type: integer
-                    format: uint64
-                content:
-                    type: string
-                maybe:
-                    type: string
 tags:
     - name: Messaging

--- a/cmd/protoc-gen-openapi/examples/tests/additional_bindings/openapi_fq_schema_naming.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/additional_bindings/openapi_fq_schema_naming.yaml
@@ -6,39 +6,35 @@ info:
     title: Messaging API
     version: 0.0.1
 paths:
-    /v1/messages/{messageId}:
-        get:
+    /v1/messages:
+        patch:
             tags:
                 - Messaging
-            operationId: Messaging_GetMessage
-            parameters:
-                - name: messageId
-                  in: path
-                  required: true
-                  schema:
-                    type: string
-                - name: userId
-                  in: query
-                  schema:
-                    type: integer
-                    format: uint64
+            operationId: Messaging_UpdateMessage
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/tests.additional_bindings.message.v1.Message'
+                required: true
             responses:
                 "200":
                     description: OK
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/tests.pathparams.message.v1.Message'
+                                $ref: '#/components/schemas/tests.additional_bindings.message.v1.Message'
                 default:
                     description: Default error response
                     content:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/google.rpc.Status'
-        post:
+    /v1/messages/{messageId}:
+        patch:
             tags:
                 - Messaging
-            operationId: Messaging_CreateMessage
+            operationId: Messaging_UpdateMessage
             parameters:
                 - name: messageId
                   in: path
@@ -49,7 +45,7 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/tests.pathparams.message.v1.Message'
+                            type: string
                 required: true
             responses:
                 "200":
@@ -57,37 +53,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/tests.pathparams.message.v1.Message'
-                default:
-                    description: Default error response
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/google.rpc.Status'
-    /v1/users/{userId}/messages/{messageId}:
-        get:
-            tags:
-                - Messaging
-            operationId: Messaging_GetUserMessage
-            parameters:
-                - name: userId
-                  in: path
-                  required: true
-                  schema:
-                    type: integer
-                    format: uint64
-                - name: messageId
-                  in: path
-                  required: true
-                  schema:
-                    type: string
-            responses:
-                "200":
-                    description: OK
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/tests.pathparams.message.v1.Message'
+                                $ref: '#/components/schemas/tests.additional_bindings.message.v1.Message'
                 default:
                     description: Default error response
                     content:
@@ -120,17 +86,12 @@ components:
                         $ref: '#/components/schemas/google.protobuf.Any'
                     description: A list of messages that carry the error details.  There is a common set of message types for APIs to use.
             description: 'The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors).'
-        tests.pathparams.message.v1.Message:
+        tests.additional_bindings.message.v1.Message:
             type: object
             properties:
                 messageId:
                     type: string
-                userId:
-                    type: integer
-                    format: uint64
-                content:
-                    type: string
-                maybe:
+                text:
                     type: string
 tags:
     - name: Messaging

--- a/cmd/protoc-gen-openapi/examples/tests/additional_bindings/openapi_json.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/additional_bindings/openapi_json.yaml
@@ -4,41 +4,37 @@
 openapi: 3.0.3
 info:
     title: Messaging API
-    version: 0.0.1
+    version: 1.2.3
 paths:
-    /v1/messages/{messageId}:
-        get:
+    /v1/messages:
+        patch:
             tags:
                 - Messaging
-            operationId: Messaging_GetMessage
-            parameters:
-                - name: messageId
-                  in: path
-                  required: true
-                  schema:
-                    type: string
-                - name: userId
-                  in: query
-                  schema:
-                    type: integer
-                    format: uint64
+            operationId: Messaging_UpdateMessage
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/Message'
+                required: true
             responses:
                 "200":
                     description: OK
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/tests.pathparams.message.v1.Message'
+                                $ref: '#/components/schemas/Message'
                 default:
                     description: Default error response
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/google.rpc.Status'
-        post:
+                                $ref: '#/components/schemas/Status'
+    /v1/messages/{messageId}:
+        patch:
             tags:
                 - Messaging
-            operationId: Messaging_CreateMessage
+            operationId: Messaging_UpdateMessage
             parameters:
                 - name: messageId
                   in: path
@@ -49,7 +45,7 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/tests.pathparams.message.v1.Message'
+                            type: string
                 required: true
             responses:
                 "200":
@@ -57,46 +53,16 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/tests.pathparams.message.v1.Message'
+                                $ref: '#/components/schemas/Message'
                 default:
                     description: Default error response
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/google.rpc.Status'
-    /v1/users/{userId}/messages/{messageId}:
-        get:
-            tags:
-                - Messaging
-            operationId: Messaging_GetUserMessage
-            parameters:
-                - name: userId
-                  in: path
-                  required: true
-                  schema:
-                    type: integer
-                    format: uint64
-                - name: messageId
-                  in: path
-                  required: true
-                  schema:
-                    type: string
-            responses:
-                "200":
-                    description: OK
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/tests.pathparams.message.v1.Message'
-                default:
-                    description: Default error response
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/google.rpc.Status'
+                                $ref: '#/components/schemas/Status'
 components:
     schemas:
-        google.protobuf.Any:
+        GoogleProtobufAny:
             type: object
             properties:
                 '@type':
@@ -104,7 +70,14 @@ components:
                     description: The type of the serialized message.
             additionalProperties: true
             description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
-        google.rpc.Status:
+        Message:
+            type: object
+            properties:
+                messageId:
+                    type: string
+                text:
+                    type: string
+        Status:
             type: object
             properties:
                 code:
@@ -117,20 +90,8 @@ components:
                 details:
                     type: array
                     items:
-                        $ref: '#/components/schemas/google.protobuf.Any'
+                        $ref: '#/components/schemas/GoogleProtobufAny'
                     description: A list of messages that carry the error details.  There is a common set of message types for APIs to use.
             description: 'The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors).'
-        tests.pathparams.message.v1.Message:
-            type: object
-            properties:
-                messageId:
-                    type: string
-                userId:
-                    type: integer
-                    format: uint64
-                content:
-                    type: string
-                maybe:
-                    type: string
 tags:
     - name: Messaging

--- a/cmd/protoc-gen-openapi/examples/tests/additional_bindings/openapi_string_enum.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/additional_bindings/openapi_string_enum.yaml
@@ -6,39 +6,35 @@ info:
     title: Messaging API
     version: 0.0.1
 paths:
-    /v1/messages/{messageId}:
-        get:
+    /v1/messages:
+        patch:
             tags:
                 - Messaging
-            operationId: Messaging_GetMessage
-            parameters:
-                - name: messageId
-                  in: path
-                  required: true
-                  schema:
-                    type: string
-                - name: userId
-                  in: query
-                  schema:
-                    type: integer
-                    format: uint64
+            operationId: Messaging_UpdateMessage
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/Message'
+                required: true
             responses:
                 "200":
                     description: OK
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/tests.pathparams.message.v1.Message'
+                                $ref: '#/components/schemas/Message'
                 default:
                     description: Default error response
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/google.rpc.Status'
-        post:
+                                $ref: '#/components/schemas/Status'
+    /v1/messages/{messageId}:
+        patch:
             tags:
                 - Messaging
-            operationId: Messaging_CreateMessage
+            operationId: Messaging_UpdateMessage
             parameters:
                 - name: messageId
                   in: path
@@ -49,7 +45,7 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/tests.pathparams.message.v1.Message'
+                            type: string
                 required: true
             responses:
                 "200":
@@ -57,46 +53,16 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/tests.pathparams.message.v1.Message'
+                                $ref: '#/components/schemas/Message'
                 default:
                     description: Default error response
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/google.rpc.Status'
-    /v1/users/{userId}/messages/{messageId}:
-        get:
-            tags:
-                - Messaging
-            operationId: Messaging_GetUserMessage
-            parameters:
-                - name: userId
-                  in: path
-                  required: true
-                  schema:
-                    type: integer
-                    format: uint64
-                - name: messageId
-                  in: path
-                  required: true
-                  schema:
-                    type: string
-            responses:
-                "200":
-                    description: OK
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/tests.pathparams.message.v1.Message'
-                default:
-                    description: Default error response
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/google.rpc.Status'
+                                $ref: '#/components/schemas/Status'
 components:
     schemas:
-        google.protobuf.Any:
+        GoogleProtobufAny:
             type: object
             properties:
                 '@type':
@@ -104,7 +70,14 @@ components:
                     description: The type of the serialized message.
             additionalProperties: true
             description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
-        google.rpc.Status:
+        Message:
+            type: object
+            properties:
+                messageId:
+                    type: string
+                text:
+                    type: string
+        Status:
             type: object
             properties:
                 code:
@@ -117,20 +90,8 @@ components:
                 details:
                     type: array
                     items:
-                        $ref: '#/components/schemas/google.protobuf.Any'
+                        $ref: '#/components/schemas/GoogleProtobufAny'
                     description: A list of messages that carry the error details.  There is a common set of message types for APIs to use.
             description: 'The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors).'
-        tests.pathparams.message.v1.Message:
-            type: object
-            properties:
-                messageId:
-                    type: string
-                userId:
-                    type: integer
-                    format: uint64
-                content:
-                    type: string
-                maybe:
-                    type: string
 tags:
     - name: Messaging

--- a/cmd/protoc-gen-openapi/examples/tests/allofwrap/openapi_default_response.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/allofwrap/openapi_default_response.yaml
@@ -3,14 +3,14 @@
 
 openapi: 3.0.3
 info:
-    title: Messaging1 API
+    title: Messaging API
     version: 0.0.1
 paths:
     /v1/messages/{message_id}:
         patch:
             tags:
-                - Messaging1
-            operationId: Messaging1_UpdateMessage
+                - Messaging
+            operationId: Messaging_UpdateMessage
             parameters:
                 - name: message_id
                   in: path
@@ -21,7 +21,7 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/tests.noannotations.message.v1.Message'
+                            $ref: '#/components/schemas/Message'
                 required: true
             responses:
                 "200":
@@ -29,16 +29,16 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/tests.noannotations.message.v1.Message'
+                                $ref: '#/components/schemas/Message'
                 default:
                     description: Default error response
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/google.rpc.Status'
+                                $ref: '#/components/schemas/Status'
 components:
     schemas:
-        google.protobuf.Any:
+        GoogleProtobufAny:
             type: object
             properties:
                 '@type':
@@ -46,7 +46,35 @@ components:
                     description: The type of the serialized message.
             additionalProperties: true
             description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
-        google.rpc.Status:
+        Message:
+            type: object
+            properties:
+                sub:
+                    $ref: '#/components/schemas/Message_Sub'
+                subInput:
+                    writeOnly: true
+                    allOf:
+                        - $ref: '#/components/schemas/Message_Sub'
+                subOutput:
+                    readOnly: true
+                    allOf:
+                        - $ref: '#/components/schemas/Message_Sub'
+                subDesc:
+                    allOf:
+                        - $ref: '#/components/schemas/Message_Sub'
+                    description: this sub has a description
+                subs:
+                    readOnly: true
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Message_Sub'
+                    description: test repeated, should not allof wrapped
+        Message_Sub:
+            type: object
+            properties:
+                content:
+                    type: string
+        Status:
             type: object
             properties:
                 code:
@@ -59,16 +87,8 @@ components:
                 details:
                     type: array
                     items:
-                        $ref: '#/components/schemas/google.protobuf.Any'
+                        $ref: '#/components/schemas/GoogleProtobufAny'
                     description: A list of messages that carry the error details.  There is a common set of message types for APIs to use.
             description: 'The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors).'
-        tests.noannotations.message.v1.Message:
-            type: object
-            properties:
-                id:
-                    type: integer
-                    format: int64
-                label:
-                    type: string
 tags:
-    - name: Messaging1
+    - name: Messaging

--- a/cmd/protoc-gen-openapi/examples/tests/allofwrap/openapi_fq_schema_naming.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/allofwrap/openapi_fq_schema_naming.yaml
@@ -6,41 +6,13 @@ info:
     title: Messaging API
     version: 0.0.1
 paths:
-    /v1/messages/{messageId}:
-        get:
+    /v1/messages/{message_id}:
+        patch:
             tags:
                 - Messaging
-            operationId: Messaging_GetMessage
+            operationId: Messaging_UpdateMessage
             parameters:
-                - name: messageId
-                  in: path
-                  required: true
-                  schema:
-                    type: string
-                - name: userId
-                  in: query
-                  schema:
-                    type: integer
-                    format: uint64
-            responses:
-                "200":
-                    description: OK
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/tests.pathparams.message.v1.Message'
-                default:
-                    description: Default error response
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/google.rpc.Status'
-        post:
-            tags:
-                - Messaging
-            operationId: Messaging_CreateMessage
-            parameters:
-                - name: messageId
+                - name: message_id
                   in: path
                   required: true
                   schema:
@@ -49,7 +21,7 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/tests.pathparams.message.v1.Message'
+                            $ref: '#/components/schemas/tests.allofwrap.message.v1.Message'
                 required: true
             responses:
                 "200":
@@ -57,37 +29,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/tests.pathparams.message.v1.Message'
-                default:
-                    description: Default error response
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/google.rpc.Status'
-    /v1/users/{userId}/messages/{messageId}:
-        get:
-            tags:
-                - Messaging
-            operationId: Messaging_GetUserMessage
-            parameters:
-                - name: userId
-                  in: path
-                  required: true
-                  schema:
-                    type: integer
-                    format: uint64
-                - name: messageId
-                  in: path
-                  required: true
-                  schema:
-                    type: string
-            responses:
-                "200":
-                    description: OK
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/tests.pathparams.message.v1.Message'
+                                $ref: '#/components/schemas/tests.allofwrap.message.v1.Message'
                 default:
                     description: Default error response
                     content:
@@ -120,17 +62,33 @@ components:
                         $ref: '#/components/schemas/google.protobuf.Any'
                     description: A list of messages that carry the error details.  There is a common set of message types for APIs to use.
             description: 'The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors).'
-        tests.pathparams.message.v1.Message:
+        tests.allofwrap.message.v1.Message:
             type: object
             properties:
-                messageId:
-                    type: string
-                userId:
-                    type: integer
-                    format: uint64
+                sub:
+                    $ref: '#/components/schemas/tests.allofwrap.message.v1.Message_Sub'
+                subInput:
+                    writeOnly: true
+                    allOf:
+                        - $ref: '#/components/schemas/tests.allofwrap.message.v1.Message_Sub'
+                subOutput:
+                    readOnly: true
+                    allOf:
+                        - $ref: '#/components/schemas/tests.allofwrap.message.v1.Message_Sub'
+                subDesc:
+                    allOf:
+                        - $ref: '#/components/schemas/tests.allofwrap.message.v1.Message_Sub'
+                    description: this sub has a description
+                subs:
+                    readOnly: true
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/tests.allofwrap.message.v1.Message_Sub'
+                    description: test repeated, should not allof wrapped
+        tests.allofwrap.message.v1.Message_Sub:
+            type: object
+            properties:
                 content:
-                    type: string
-                maybe:
                     type: string
 tags:
     - name: Messaging

--- a/cmd/protoc-gen-openapi/examples/tests/allofwrap/openapi_json.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/allofwrap/openapi_json.yaml
@@ -3,14 +3,14 @@
 
 openapi: 3.0.3
 info:
-    title: Messaging1 API
-    version: 0.0.1
+    title: Messaging API
+    version: 1.2.3
 paths:
     /v1/messages/{message_id}:
         patch:
             tags:
-                - Messaging1
-            operationId: Messaging1_UpdateMessage
+                - Messaging
+            operationId: Messaging_UpdateMessage
             parameters:
                 - name: message_id
                   in: path
@@ -21,7 +21,7 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/tests.noannotations.message.v1.Message'
+                            $ref: '#/components/schemas/Message'
                 required: true
             responses:
                 "200":
@@ -29,16 +29,16 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/tests.noannotations.message.v1.Message'
+                                $ref: '#/components/schemas/Message'
                 default:
                     description: Default error response
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/google.rpc.Status'
+                                $ref: '#/components/schemas/Status'
 components:
     schemas:
-        google.protobuf.Any:
+        GoogleProtobufAny:
             type: object
             properties:
                 '@type':
@@ -46,7 +46,35 @@ components:
                     description: The type of the serialized message.
             additionalProperties: true
             description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
-        google.rpc.Status:
+        Message:
+            type: object
+            properties:
+                sub:
+                    $ref: '#/components/schemas/Message_Sub'
+                subInput:
+                    writeOnly: true
+                    allOf:
+                        - $ref: '#/components/schemas/Message_Sub'
+                subOutput:
+                    readOnly: true
+                    allOf:
+                        - $ref: '#/components/schemas/Message_Sub'
+                subDesc:
+                    allOf:
+                        - $ref: '#/components/schemas/Message_Sub'
+                    description: this sub has a description
+                subs:
+                    readOnly: true
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Message_Sub'
+                    description: test repeated, should not allof wrapped
+        Message_Sub:
+            type: object
+            properties:
+                content:
+                    type: string
+        Status:
             type: object
             properties:
                 code:
@@ -59,16 +87,8 @@ components:
                 details:
                     type: array
                     items:
-                        $ref: '#/components/schemas/google.protobuf.Any'
+                        $ref: '#/components/schemas/GoogleProtobufAny'
                     description: A list of messages that carry the error details.  There is a common set of message types for APIs to use.
             description: 'The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors).'
-        tests.noannotations.message.v1.Message:
-            type: object
-            properties:
-                id:
-                    type: integer
-                    format: int64
-                label:
-                    type: string
 tags:
-    - name: Messaging1
+    - name: Messaging

--- a/cmd/protoc-gen-openapi/examples/tests/allofwrap/openapi_string_enum.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/allofwrap/openapi_string_enum.yaml
@@ -3,14 +3,14 @@
 
 openapi: 3.0.3
 info:
-    title: Messaging1 API
+    title: Messaging API
     version: 0.0.1
 paths:
     /v1/messages/{message_id}:
         patch:
             tags:
-                - Messaging1
-            operationId: Messaging1_UpdateMessage
+                - Messaging
+            operationId: Messaging_UpdateMessage
             parameters:
                 - name: message_id
                   in: path
@@ -21,7 +21,7 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/tests.noannotations.message.v1.Message'
+                            $ref: '#/components/schemas/Message'
                 required: true
             responses:
                 "200":
@@ -29,16 +29,16 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/tests.noannotations.message.v1.Message'
+                                $ref: '#/components/schemas/Message'
                 default:
                     description: Default error response
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/google.rpc.Status'
+                                $ref: '#/components/schemas/Status'
 components:
     schemas:
-        google.protobuf.Any:
+        GoogleProtobufAny:
             type: object
             properties:
                 '@type':
@@ -46,7 +46,35 @@ components:
                     description: The type of the serialized message.
             additionalProperties: true
             description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
-        google.rpc.Status:
+        Message:
+            type: object
+            properties:
+                sub:
+                    $ref: '#/components/schemas/Message_Sub'
+                subInput:
+                    writeOnly: true
+                    allOf:
+                        - $ref: '#/components/schemas/Message_Sub'
+                subOutput:
+                    readOnly: true
+                    allOf:
+                        - $ref: '#/components/schemas/Message_Sub'
+                subDesc:
+                    allOf:
+                        - $ref: '#/components/schemas/Message_Sub'
+                    description: this sub has a description
+                subs:
+                    readOnly: true
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Message_Sub'
+                    description: test repeated, should not allof wrapped
+        Message_Sub:
+            type: object
+            properties:
+                content:
+                    type: string
+        Status:
             type: object
             properties:
                 code:
@@ -59,16 +87,8 @@ components:
                 details:
                     type: array
                     items:
-                        $ref: '#/components/schemas/google.protobuf.Any'
+                        $ref: '#/components/schemas/GoogleProtobufAny'
                     description: A list of messages that carry the error details.  There is a common set of message types for APIs to use.
             description: 'The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors).'
-        tests.noannotations.message.v1.Message:
-            type: object
-            properties:
-                id:
-                    type: integer
-                    format: int64
-                label:
-                    type: string
 tags:
-    - name: Messaging1
+    - name: Messaging

--- a/cmd/protoc-gen-openapi/examples/tests/mapfields/openapi.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/mapfields/openapi.yaml
@@ -42,7 +42,8 @@ components:
             type: object
             properties:
                 id:
-                    type: string
+                    type: integer
+                    format: int64
                 label:
                     type: string
         GoogleProtobufAny:
@@ -90,7 +91,8 @@ components:
             type: object
             properties:
                 id:
-                    type: string
+                    type: integer
+                    format: int64
                 label:
                     type: string
         Status:

--- a/cmd/protoc-gen-openapi/examples/tests/mapfields/openapi_default_response.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/mapfields/openapi_default_response.yaml
@@ -42,7 +42,8 @@ components:
             type: object
             properties:
                 id:
-                    type: string
+                    type: integer
+                    format: int64
                 label:
                     type: string
         GoogleProtobufAny:
@@ -90,7 +91,8 @@ components:
             type: object
             properties:
                 id:
-                    type: string
+                    type: integer
+                    format: int64
                 label:
                     type: string
         Status:

--- a/cmd/protoc-gen-openapi/examples/tests/mapfields/openapi_fq_schema_naming.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/mapfields/openapi_fq_schema_naming.yaml
@@ -66,7 +66,8 @@ components:
             type: object
             properties:
                 id:
-                    type: string
+                    type: integer
+                    format: int64
                 label:
                     type: string
         tests.mapfields.message.v1.Message:
@@ -106,7 +107,8 @@ components:
             type: object
             properties:
                 id:
-                    type: string
+                    type: integer
+                    format: int64
                 label:
                     type: string
 tags:

--- a/cmd/protoc-gen-openapi/examples/tests/mapfields/openapi_json.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/mapfields/openapi_json.yaml
@@ -42,7 +42,8 @@ components:
             type: object
             properties:
                 id:
-                    type: string
+                    type: integer
+                    format: int64
                 label:
                     type: string
         GoogleProtobufAny:
@@ -90,7 +91,8 @@ components:
             type: object
             properties:
                 id:
-                    type: string
+                    type: integer
+                    format: int64
                 label:
                     type: string
         Status:

--- a/cmd/protoc-gen-openapi/examples/tests/mapfields/openapi_string_enum.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/mapfields/openapi_string_enum.yaml
@@ -42,7 +42,8 @@ components:
             type: object
             properties:
                 id:
-                    type: string
+                    type: integer
+                    format: int64
                 label:
                     type: string
         GoogleProtobufAny:
@@ -90,7 +91,8 @@ components:
             type: object
             properties:
                 id:
-                    type: string
+                    type: integer
+                    format: int64
                 label:
                     type: string
         Status:

--- a/cmd/protoc-gen-openapi/examples/tests/noannotations/openapi.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/noannotations/openapi.yaml
@@ -50,7 +50,8 @@ components:
             type: object
             properties:
                 id:
-                    type: string
+                    type: integer
+                    format: int64
                 label:
                     type: string
         Status:

--- a/cmd/protoc-gen-openapi/examples/tests/noannotations/openapi_default_response.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/noannotations/openapi_default_response.yaml
@@ -50,7 +50,8 @@ components:
             type: object
             properties:
                 id:
-                    type: string
+                    type: integer
+                    format: int64
                 label:
                     type: string
         Status:

--- a/cmd/protoc-gen-openapi/examples/tests/noannotations/openapi_json.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/noannotations/openapi_json.yaml
@@ -50,7 +50,8 @@ components:
             type: object
             properties:
                 id:
-                    type: string
+                    type: integer
+                    format: int64
                 label:
                     type: string
         Status:

--- a/cmd/protoc-gen-openapi/examples/tests/noannotations/openapi_string_enum.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/noannotations/openapi_string_enum.yaml
@@ -50,7 +50,8 @@ components:
             type: object
             properties:
                 id:
-                    type: string
+                    type: integer
+                    format: int64
                 label:
                     type: string
         Status:

--- a/cmd/protoc-gen-openapi/examples/tests/openapiv3annotations/openapi.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/openapiv3annotations/openapi.yaml
@@ -61,7 +61,8 @@ components:
             type: object
             properties:
                 id:
-                    type: string
+                    type: integer
+                    format: int64
                 label:
                     title: this is an overriden field schema title
                     maxLength: 255

--- a/cmd/protoc-gen-openapi/examples/tests/openapiv3annotations/openapi_default_response.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/openapiv3annotations/openapi_default_response.yaml
@@ -61,7 +61,8 @@ components:
             type: object
             properties:
                 id:
-                    type: string
+                    type: integer
+                    format: int64
                 label:
                     title: this is an overriden field schema title
                     maxLength: 255

--- a/cmd/protoc-gen-openapi/examples/tests/openapiv3annotations/openapi_fq_schema_naming.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/openapiv3annotations/openapi_fq_schema_naming.yaml
@@ -77,7 +77,8 @@ components:
             type: object
             properties:
                 id:
-                    type: string
+                    type: integer
+                    format: int64
                 label:
                     title: this is an overriden field schema title
                     maxLength: 255

--- a/cmd/protoc-gen-openapi/examples/tests/openapiv3annotations/openapi_json.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/openapiv3annotations/openapi_json.yaml
@@ -61,7 +61,8 @@ components:
             type: object
             properties:
                 id:
-                    type: string
+                    type: integer
+                    format: int64
                 label:
                     title: this is an overriden field schema title
                     maxLength: 255

--- a/cmd/protoc-gen-openapi/examples/tests/openapiv3annotations/openapi_string_enum.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/openapiv3annotations/openapi_string_enum.yaml
@@ -61,7 +61,8 @@ components:
             type: object
             properties:
                 id:
-                    type: string
+                    type: integer
+                    format: int64
                 label:
                     title: this is an overriden field schema title
                     maxLength: 255

--- a/cmd/protoc-gen-openapi/examples/tests/pathparams/openapi.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/pathparams/openapi.yaml
@@ -20,7 +20,8 @@ paths:
                 - name: user_id
                   in: query
                   schema:
-                    type: string
+                    type: integer
+                    format: uint64
             responses:
                 "200":
                     description: OK
@@ -73,7 +74,8 @@ paths:
                   in: path
                   required: true
                   schema:
-                    type: string
+                    type: integer
+                    format: uint64
                 - name: message_id
                   in: path
                   required: true
@@ -108,7 +110,8 @@ components:
                 message_id:
                     type: string
                 user_id:
-                    type: string
+                    type: integer
+                    format: uint64
                 content:
                     type: string
                 maybe:

--- a/cmd/protoc-gen-openapi/examples/tests/pathparams/openapi_default_response.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/pathparams/openapi_default_response.yaml
@@ -20,7 +20,8 @@ paths:
                 - name: userId
                   in: query
                   schema:
-                    type: string
+                    type: integer
+                    format: uint64
             responses:
                 "200":
                     description: OK
@@ -73,7 +74,8 @@ paths:
                   in: path
                   required: true
                   schema:
-                    type: string
+                    type: integer
+                    format: uint64
                 - name: messageId
                   in: path
                   required: true
@@ -108,7 +110,8 @@ components:
                 messageId:
                     type: string
                 userId:
-                    type: string
+                    type: integer
+                    format: uint64
                 content:
                     type: string
                 maybe:

--- a/cmd/protoc-gen-openapi/examples/tests/pathparams/openapi_json.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/pathparams/openapi_json.yaml
@@ -20,7 +20,8 @@ paths:
                 - name: userId
                   in: query
                   schema:
-                    type: string
+                    type: integer
+                    format: uint64
             responses:
                 "200":
                     description: OK
@@ -73,7 +74,8 @@ paths:
                   in: path
                   required: true
                   schema:
-                    type: string
+                    type: integer
+                    format: uint64
                 - name: messageId
                   in: path
                   required: true
@@ -108,7 +110,8 @@ components:
                 messageId:
                     type: string
                 userId:
-                    type: string
+                    type: integer
+                    format: uint64
                 content:
                     type: string
                 maybe:

--- a/cmd/protoc-gen-openapi/examples/tests/pathparams/openapi_string_enum.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/pathparams/openapi_string_enum.yaml
@@ -20,7 +20,8 @@ paths:
                 - name: userId
                   in: query
                   schema:
-                    type: string
+                    type: integer
+                    format: uint64
             responses:
                 "200":
                     description: OK
@@ -73,7 +74,8 @@ paths:
                   in: path
                   required: true
                   schema:
-                    type: string
+                    type: integer
+                    format: uint64
                 - name: messageId
                   in: path
                   required: true
@@ -108,7 +110,8 @@ components:
                 messageId:
                     type: string
                 userId:
-                    type: string
+                    type: integer
+                    format: uint64
                 content:
                     type: string
                 maybe:

--- a/cmd/protoc-gen-openapi/examples/tests/protobuftypes/openapi.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/protobuftypes/openapi.yaml
@@ -124,11 +124,13 @@ paths:
                 - name: int64_value_type
                   in: query
                   schema:
-                    type: string
+                    type: integer
+                    format: int64
                 - name: uint64_value_type
                   in: query
                   schema:
-                    type: string
+                    type: integer
+                    format: uint64
                 - name: float_value_type
                   in: query
                   schema:
@@ -289,11 +291,13 @@ paths:
                 - name: int64_value_type
                   in: query
                   schema:
-                    type: string
+                    type: integer
+                    format: int64
                 - name: uint64_value_type
                   in: query
                   schema:
-                    type: string
+                    type: integer
+                    format: uint64
                 - name: float_value_type
                   in: query
                   schema:

--- a/cmd/protoc-gen-openapi/examples/tests/protobuftypes/openapi_default_response.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/protobuftypes/openapi_default_response.yaml
@@ -124,11 +124,13 @@ paths:
                 - name: int64ValueType
                   in: query
                   schema:
-                    type: string
+                    type: integer
+                    format: int64
                 - name: uint64ValueType
                   in: query
                   schema:
-                    type: string
+                    type: integer
+                    format: uint64
                 - name: floatValueType
                   in: query
                   schema:
@@ -289,11 +291,13 @@ paths:
                 - name: int64ValueType
                   in: query
                   schema:
-                    type: string
+                    type: integer
+                    format: int64
                 - name: uint64ValueType
                   in: query
                   schema:
-                    type: string
+                    type: integer
+                    format: uint64
                 - name: floatValueType
                   in: query
                   schema:

--- a/cmd/protoc-gen-openapi/examples/tests/protobuftypes/openapi_fq_schema_naming.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/protobuftypes/openapi_fq_schema_naming.yaml
@@ -124,11 +124,13 @@ paths:
                 - name: int64ValueType
                   in: query
                   schema:
-                    type: string
+                    type: integer
+                    format: int64
                 - name: uint64ValueType
                   in: query
                   schema:
-                    type: string
+                    type: integer
+                    format: uint64
                 - name: floatValueType
                   in: query
                   schema:
@@ -289,11 +291,13 @@ paths:
                 - name: int64ValueType
                   in: query
                   schema:
-                    type: string
+                    type: integer
+                    format: int64
                 - name: uint64ValueType
                   in: query
                   schema:
-                    type: string
+                    type: integer
+                    format: uint64
                 - name: floatValueType
                   in: query
                   schema:

--- a/cmd/protoc-gen-openapi/examples/tests/protobuftypes/openapi_json.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/protobuftypes/openapi_json.yaml
@@ -124,11 +124,13 @@ paths:
                 - name: int64ValueType
                   in: query
                   schema:
-                    type: string
+                    type: integer
+                    format: int64
                 - name: uint64ValueType
                   in: query
                   schema:
-                    type: string
+                    type: integer
+                    format: uint64
                 - name: floatValueType
                   in: query
                   schema:
@@ -289,11 +291,13 @@ paths:
                 - name: int64ValueType
                   in: query
                   schema:
-                    type: string
+                    type: integer
+                    format: int64
                 - name: uint64ValueType
                   in: query
                   schema:
-                    type: string
+                    type: integer
+                    format: uint64
                 - name: floatValueType
                   in: query
                   schema:

--- a/cmd/protoc-gen-openapi/examples/tests/protobuftypes/openapi_string_enum.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/protobuftypes/openapi_string_enum.yaml
@@ -124,11 +124,13 @@ paths:
                 - name: int64ValueType
                   in: query
                   schema:
-                    type: string
+                    type: integer
+                    format: int64
                 - name: uint64ValueType
                   in: query
                   schema:
-                    type: string
+                    type: integer
+                    format: uint64
                 - name: floatValueType
                   in: query
                   schema:
@@ -289,11 +291,13 @@ paths:
                 - name: int64ValueType
                   in: query
                   schema:
-                    type: string
+                    type: integer
+                    format: int64
                 - name: uint64ValueType
                   in: query
                   schema:
-                    type: string
+                    type: integer
+                    format: uint64
                 - name: floatValueType
                   in: query
                   schema:

--- a/cmd/protoc-gen-openapi/generator/reflector.go
+++ b/cmd/protoc-gen-openapi/generator/reflector.go
@@ -160,10 +160,10 @@ func (r *OpenAPIv3Reflector) schemaOrReferenceForMessage(message protoreflect.Me
 	case ".google.protobuf.BytesValue":
 		return wk.NewBytesSchema()
 
-	case ".google.protobuf.Int32Value", ".google.protobuf.UInt32Value":
+	case ".google.protobuf.Int32Value", ".google.protobuf.UInt32Value", ".google.protobuf.Int64Value", ".google.protobuf.UInt64Value":
 		return wk.NewIntegerSchema(getValueKind(message))
 
-	case ".google.protobuf.StringValue", ".google.protobuf.Int64Value", ".google.protobuf.UInt64Value":
+	case ".google.protobuf.StringValue":
 		return wk.NewStringSchema()
 
 	case ".google.protobuf.FloatValue", ".google.protobuf.DoubleValue":
@@ -208,12 +208,10 @@ func (r *OpenAPIv3Reflector) schemaOrReferenceForField(field protoreflect.FieldD
 		kindSchema = wk.NewStringSchema()
 
 	case protoreflect.Int32Kind, protoreflect.Sint32Kind, protoreflect.Uint32Kind,
-		protoreflect.Sfixed32Kind, protoreflect.Fixed32Kind:
-		kindSchema = wk.NewIntegerSchema(kind.String())
-
-	case protoreflect.Int64Kind, protoreflect.Sint64Kind, protoreflect.Uint64Kind,
+		protoreflect.Sfixed32Kind, protoreflect.Fixed32Kind,
+		protoreflect.Int64Kind, protoreflect.Sint64Kind, protoreflect.Uint64Kind,
 		protoreflect.Sfixed64Kind, protoreflect.Fixed64Kind:
-		kindSchema = wk.NewStringSchema()
+		kindSchema = wk.NewIntegerSchema(kind.String())
 
 	case protoreflect.EnumKind:
 		kindSchema = wk.NewEnumSchema(*&r.conf.EnumType, field)


### PR DESCRIPTION
# Description of the Bug

Protobuf int64, sint64, uint64, sfixed64, and fixed64 types were incorrectly being generated as string type in OpenAPI schemas. OpenAPI specification supports int64 as integer type with format specifier, so this change moves 64-bit integer types from string generation to integer generation with appropriate format.

This appears to have been a regression between version v0.6.9 and v0.7.0 of the protoc-gen-openapi generator.

The current code only treats 32 bit integer types as an integer but 64 bit integers as a raw string, this is against the openapi v2 and v3 spec. See the Data Types sections for both versions 

https://swagger.io/specification/v2/ 
https://swagger.io/specification/v3/

<img width="695" height="477" alt="Screenshot 2025-09-26 at 11 10 36 AM" src="https://github.com/user-attachments/assets/932e9d4f-44cb-43c3-8ac6-06804512478e" />

This bug results in incorrectly generated openapi files where int64s are written into the specs as being raw strings. This has the the downstream effect of any generated client will treat the integers as string values and require special parsing by the user of the client to parse the long value out of the string.

Examples of the correct values are in the fixture but here is a snippet of what the change in the generate schema looks like for int64:

```diff
 - name: int64_value_type
   in: query
   schema:
-    type: string
+    type: integer
+    format: int64
```

Fixes #411 